### PR TITLE
Add subscription reminder email logic

### DIFF
--- a/src/api/v1/services/subscription.service.ts
+++ b/src/api/v1/services/subscription.service.ts
@@ -1,3 +1,5 @@
+import { emailService } from "./email.service";
+import { memberRepository } from "../repositories/member.repository";
 import { subscriptionRepository } from "../repositories/subscription.repository";
 import {
   type CreateSubscriptionInput,
@@ -5,10 +7,63 @@ import {
   type UpdateSubscriptionInput,
 } from "../types/subscription.types";
 
+const subscriptionReminderWindowInDays = 7;
+
+const isSubscriptionEndingSoon = (
+  subscriptionEndDate: string,
+  reminderWindowInDays: number = subscriptionReminderWindowInDays,
+): boolean => {
+  const currentDate = new Date();
+  const endDate = new Date(subscriptionEndDate);
+
+  const millisecondsUntilEndDate = endDate.getTime() - currentDate.getTime();
+  const daysUntilEndDate = millisecondsUntilEndDate / (1000 * 60 * 60 * 24);
+
+  return daysUntilEndDate >= 0 && daysUntilEndDate <= reminderWindowInDays;
+};
+
+const tryToSendSubscriptionReminderEmail = async (
+  subscription: Subscription,
+): Promise<void> => {
+  if (!emailService.isEmailConfigurationAvailable()) {
+    return;
+  }
+
+  if (!subscription.isActive) {
+    return;
+  }
+
+  if (!isSubscriptionEndingSoon(subscription.endDate)) {
+    return;
+  }
+
+  const member = await memberRepository.getMemberById(subscription.memberId);
+
+  if (!member) {
+    return;
+  }
+
+  await emailService.sendSubscriptionReminderEmail(
+    member.email,
+    member.firstName,
+    subscription.endDate,
+  );
+};
+
 const createSubscription = async (
   createSubscriptionInput: CreateSubscriptionInput,
 ): Promise<Subscription> => {
-  return subscriptionRepository.createSubscription(createSubscriptionInput);
+  const createdSubscription = await subscriptionRepository.createSubscription(
+    createSubscriptionInput,
+  );
+
+  try {
+    await tryToSendSubscriptionReminderEmail(createdSubscription);
+  } catch (error) {
+    console.error("Failed to send subscription reminder email:", error);
+  }
+
+  return createdSubscription;
 };
 
 const getAllSubscriptions = async (): Promise<Subscription[]> => {
@@ -25,10 +80,22 @@ const updateSubscription = async (
   subscriptionId: string,
   updateSubscriptionInput: UpdateSubscriptionInput,
 ): Promise<Subscription | null> => {
-  return subscriptionRepository.updateSubscription(
+  const updatedSubscription = await subscriptionRepository.updateSubscription(
     subscriptionId,
     updateSubscriptionInput,
   );
+
+  if (!updatedSubscription) {
+    return null;
+  }
+
+  try {
+    await tryToSendSubscriptionReminderEmail(updatedSubscription);
+  } catch (error) {
+    console.error("Failed to send subscription reminder email:", error);
+  }
+
+  return updatedSubscription;
 };
 
 const deleteSubscription = async (


### PR DESCRIPTION
This pull request adds subscription reminder email logic to the subscription service.

Included:
- reminder window check for subscriptions ending soon
- conditional email sending for active subscriptions
- member lookup before sending the reminder
- non-blocking error handling so CRUD operations continue normally

Closes #16