### PR TITLE
Issue 22 protect member routes

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1,30 +1,23 @@
-/* ========== Design tokens ========== */
-
 :root {
   color-scheme: light;
 
-  /* Surfaces */
   --color-bg: #f3f4f6;
   --color-panel: #ffffff;
   --color-panel-hover: #eff6ff;
   --color-subtle: #f9fafb;
 
-  /* Borders */
   --color-border: #e5e7eb;
   --color-border-strong: #d1d5db;
 
-  /* Text */
   --color-text: #111827;
   --color-text-muted: #6b7280;
   --color-text-subtle: #9ca3af;
   --color-label: #374151;
 
-  /* Inputs */
   --color-input-bg: #ffffff;
   --color-input-readonly-bg: #f9fafb;
   --color-input-border: #d1d5db;
 
-  /* Accent */
   --color-accent: #2563eb;
   --color-accent-hover: #1d4ed8;
   --color-accent-soft: #dbeafe;
@@ -32,22 +25,18 @@
   --color-accent-disabled: #93c5fd;
   --color-accent-focus-ring: rgba(37, 99, 235, 0.12);
 
-  /* Secondary button */
   --color-secondary-bg: #ffffff;
   --color-secondary-hover: #f9fafb;
   --color-ghost-hover: #eff6ff;
 
-  /* Danger */
   --color-danger: #dc2626;
   --color-danger-hover: #b91c1c;
   --color-danger-soft: #fee2e2;
   --color-danger-focus-ring: rgba(220, 38, 38, 0.18);
 
-  /* Count badge */
   --color-count-bg: #e5e7eb;
   --color-count-text: #4b5563;
 
-  /* Status badges */
   --badge-active-bg: #d1fae5;
   --badge-active-text: #065f46;
   --badge-inactive-bg: #e5e7eb;
@@ -55,22 +44,18 @@
   --badge-suspended-bg: #fee2e2;
   --badge-suspended-text: #991b1b;
 
-  /* Code block */
   --color-code-bg: #0f172a;
   --color-code-text: #e5e7eb;
 
-  /* Empty state */
   --color-empty-bg: #f9fafb;
   --color-empty-border: #d1d5db;
 
-  /* Shadows */
   --shadow-hero: 0 12px 30px rgba(15, 23, 42, 0.15);
   --shadow-panel: 0 8px 24px rgba(15, 23, 42, 0.06);
   --shadow-toast: 0 10px 30px rgba(15, 23, 42, 0.15);
   --shadow-modal: 0 20px 50px rgba(15, 23, 42, 0.25);
   --shadow-active-card: 0 0 0 3px rgba(37, 99, 235, 0.12);
 
-  /* Hero status pill */
   --hero-status-bg: rgba(255, 255, 255, 0.08);
   --hero-status-border: rgba(255, 255, 255, 0.15);
   --hero-status-text: #e5e7eb;
@@ -78,12 +63,10 @@
   --hero-status-active-border: rgba(34, 197, 94, 0.35);
   --hero-status-active-text: #bbf7d0;
 
-  /* Toast */
   --toast-success-bg: #065f46;
   --toast-error-bg: #991b1b;
   --toast-text: #ffffff;
 
-  /* Modal overlay */
   --modal-overlay-bg: rgba(15, 23, 42, 0.5);
 }
 
@@ -151,8 +134,6 @@
   --modal-overlay-bg: rgba(0, 0, 0, 0.6);
 }
 
-/* ========== Page ========== */
-
 .page {
   min-height: 100vh;
   background: var(--color-bg);
@@ -167,8 +148,6 @@
   display: grid;
   gap: 24px;
 }
-
-/* ========== Hero ========== */
 
 .hero {
   background: linear-gradient(135deg, #111827, #1e3a8a);
@@ -277,8 +256,6 @@
   height: 18px;
 }
 
-/* ========== Layout ========== */
-
 .layout {
   display: grid;
   grid-template-columns: 340px 1fr;
@@ -303,8 +280,6 @@
   grid-template-columns: 1fr 1fr;
   gap: 20px;
 }
-
-/* ========== Panels ========== */
 
 .panel {
   background: var(--color-panel);
@@ -390,8 +365,6 @@
   margin-top: 0;
 }
 
-/* ========== Forms ========== */
-
 .formGrid {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
@@ -464,8 +437,6 @@ input[readonly] {
   background-position: 12px center;
   padding-left: 40px;
 }
-
-/* ========== Buttons ========== */
 
 button {
   display: inline-flex;
@@ -558,8 +529,6 @@ button.danger:disabled {
   flex: 1;
   min-width: 140px;
 }
-
-/* ========== Member list ========== */
 
 .memberList {
   display: grid;
@@ -707,7 +676,32 @@ button.danger:disabled {
   font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
 }
 
-/* ========== Response pane ========== */
+.dashboardGrid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 16px;
+}
+
+.statCard {
+  background: var(--color-subtle);
+  border: 1px solid var(--color-border);
+  border-radius: 16px;
+  padding: 18px;
+  display: grid;
+  gap: 8px;
+}
+
+.statLabel {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--color-text-muted);
+}
+
+.statValue {
+  font-size: 30px;
+  line-height: 1;
+  color: var(--color-text);
+}
 
 pre {
   margin: 0;
@@ -723,8 +717,6 @@ pre {
   min-height: 220px;
   font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
 }
-
-/* ========== Toast ========== */
 
 .toast {
   position: fixed;
@@ -775,8 +767,6 @@ pre {
     transform: translateY(0);
   }
 }
-
-/* ========== Modal ========== */
 
 .modalOverlay {
   position: fixed;
@@ -849,8 +839,6 @@ pre {
   }
 }
 
-/* ========== Responsive ========== */
-
 @media (max-width: 1100px) {
   .layout {
     grid-template-columns: 1fr;
@@ -862,6 +850,12 @@ pre {
 
   .formRow {
     grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 900px) {
+  .dashboardGrid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 }
 
@@ -908,5 +902,9 @@ pre {
 
   .actionGroup button {
     width: 100%;
+  }
+
+  .dashboardGrid {
+    grid-template-columns: 1fr;
   }
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useState } from "react";
 import {
   createMember,
+  createSubscription,
+  createVisit,
   deleteMember,
   getAdminDashboard,
   getExpiringSubscriptions,
@@ -15,6 +17,8 @@ import {
   type InactiveMembersResponse,
   type Member,
   type MemberInput,
+  type SubscriptionInput,
+  type VisitInput,
 } from "./api";
 import "./App.css";
 
@@ -41,6 +45,24 @@ const initialUpdateMemberState = {
   emergencyContactPhoneNumber: "",
   membershipStatus: "active" as MemberInput["membershipStatus"],
   joinDate: "",
+};
+
+const initialCreateSubscriptionState: SubscriptionInput = {
+  memberId: "",
+  planName: "Monthly Premium",
+  startDate: new Date().toISOString(),
+  endDate: new Date(Date.now() + 3 * 24 * 60 * 60 * 1000).toISOString(),
+  price: 49.99,
+  isActive: true,
+  paymentStatus: "paid",
+};
+
+const initialCreateVisitState: VisitInput = {
+  memberId: "",
+  visitDate: new Date().toISOString(),
+  checkInTime: "09:00",
+  checkOutTime: "10:00",
+  notes: "Workout session",
 };
 
 const getInitials = (firstName: string, lastName: string) =>
@@ -185,6 +207,10 @@ function App() {
   const [updateMemberState, setUpdateMemberState] = useState(
     initialUpdateMemberState,
   );
+  const [createSubscriptionState, setCreateSubscriptionState] =
+    useState<SubscriptionInput>(initialCreateSubscriptionState);
+  const [createVisitState, setCreateVisitState] =
+    useState<VisitInput>(initialCreateVisitState);
   const [isLoading, setIsLoading] = useState(false);
   const [toast, setToast] = useState<ToastState | null>(null);
   const [theme, setTheme] = useState<Theme>(getInitialTheme);
@@ -212,20 +238,60 @@ function App() {
       return;
     }
 
-    try {
-      const memberList = await getMembers(idToken);
-      setMembers(memberList);
-    } catch (error) {
-      const message =
-        error instanceof Error ? error.message : "Failed to load members";
-      setMembers([]);
-      setResponseOutput(JSON.stringify({ message }, null, 2));
-      showToast("error", message);
+    const memberList = await getMembers(idToken);
+    setMembers(memberList);
+  };
+
+  const loadDashboard = async () => {
+    if (!idToken) {
+      setAdminDashboard(null);
+      return;
     }
+
+    const adminDashboardResponse = await getAdminDashboard(idToken);
+    setAdminDashboard(adminDashboardResponse.dashboard);
+  };
+
+  const loadInactiveMembers = async () => {
+    if (!idToken) {
+      setInactiveMembersData(null);
+      return;
+    }
+
+    const inactiveMembersResponse = await getInactiveMembers(idToken);
+    setInactiveMembersData(inactiveMembersResponse);
+  };
+
+  const loadExpiringSubscriptions = async () => {
+    if (!idToken) {
+      setExpiringSubscriptionsData(null);
+      return;
+    }
+
+    const expiringSubscriptionsResponse =
+      await getExpiringSubscriptions(idToken);
+    setExpiringSubscriptionsData(expiringSubscriptionsResponse);
   };
 
   useEffect(() => {
-    void loadMembers();
+    const loadInitialData = async () => {
+      if (!idToken) {
+        setMembers([]);
+        return;
+      }
+
+      try {
+        await loadMembers();
+      } catch (error) {
+        const message =
+          error instanceof Error ? error.message : "Failed to load members";
+        setMembers([]);
+        setResponseOutput(JSON.stringify({ message }, null, 2));
+        showToast("error", message);
+      }
+    };
+
+    void loadInitialData();
   }, [idToken]);
 
   const handleLogin = async () => {
@@ -264,6 +330,8 @@ function App() {
     setExpiringSubscriptionsData(null);
     setSelectedMemberId("");
     setUpdateMemberState(initialUpdateMemberState);
+    setCreateSubscriptionState(initialCreateSubscriptionState);
+    setCreateVisitState(initialCreateVisitState);
     showToast("success", "Signed out");
   };
 
@@ -361,7 +429,8 @@ function App() {
     setIsLoading(true);
 
     try {
-      const expiringSubscriptionsResponse = await getExpiringSubscriptions(idToken);
+      const expiringSubscriptionsResponse =
+        await getExpiringSubscriptions(idToken);
       setExpiringSubscriptionsData(expiringSubscriptionsResponse);
       setResponseOutput(JSON.stringify(expiringSubscriptionsResponse, null, 2));
       showToast("success", "Expiring subscriptions loaded");
@@ -425,6 +494,10 @@ function App() {
       setResponseOutput(JSON.stringify(createMemberResponse, null, 2));
       await loadMembers();
 
+      if (adminDashboard) {
+        await loadDashboard();
+      }
+
       showToast(
         "success",
         `Created ${createMemberResponse.firstName ?? "member"} ${
@@ -447,12 +520,111 @@ function App() {
           membershipStatus: createMemberResponse.membershipStatus ?? "active",
           joinDate: createMemberResponse.joinDate ?? "",
         });
+
+        setCreateSubscriptionState((currentState) => ({
+          ...currentState,
+          memberId: createMemberResponse.id,
+        }));
+
+        setCreateVisitState((currentState) => ({
+          ...currentState,
+          memberId: createMemberResponse.id,
+        }));
       }
     } catch (error) {
       const message =
         error instanceof Error
           ? error.message
           : "Create member request failed";
+
+      setResponseOutput(JSON.stringify({ message }, null, 2));
+      showToast("error", message);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleCreateSubscription = async () => {
+    if (!idToken) {
+      const message = "Admin login is required.";
+      setResponseOutput(JSON.stringify({ message }, null, 2));
+      showToast("error", message);
+      return;
+    }
+
+    if (!createSubscriptionState.memberId) {
+      const message = "Select a member for the subscription.";
+      setResponseOutput(JSON.stringify({ message }, null, 2));
+      showToast("error", message);
+      return;
+    }
+
+    setIsLoading(true);
+
+    try {
+      const subscriptionResponse = await createSubscription(
+        idToken,
+        createSubscriptionState,
+      );
+
+      setResponseOutput(JSON.stringify(subscriptionResponse, null, 2));
+
+      if (adminDashboard) {
+        await loadDashboard();
+      }
+
+      if (expiringSubscriptionsData) {
+        await loadExpiringSubscriptions();
+      }
+
+      showToast("success", "Subscription created");
+    } catch (error) {
+      const message =
+        error instanceof Error
+          ? error.message
+          : "Create subscription request failed";
+
+      setResponseOutput(JSON.stringify({ message }, null, 2));
+      showToast("error", message);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleCreateVisit = async () => {
+    if (!idToken) {
+      const message = "Admin login is required.";
+      setResponseOutput(JSON.stringify({ message }, null, 2));
+      showToast("error", message);
+      return;
+    }
+
+    if (!createVisitState.memberId) {
+      const message = "Select a member for the visit.";
+      setResponseOutput(JSON.stringify({ message }, null, 2));
+      showToast("error", message);
+      return;
+    }
+
+    setIsLoading(true);
+
+    try {
+      const visitResponse = await createVisit(idToken, createVisitState);
+
+      setResponseOutput(JSON.stringify(visitResponse, null, 2));
+
+      if (adminDashboard) {
+        await loadDashboard();
+      }
+
+      if (inactiveMembersData) {
+        await loadInactiveMembers();
+      }
+
+      showToast("success", "Visit created");
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : "Create visit request failed";
 
       setResponseOutput(JSON.stringify({ message }, null, 2));
       showToast("error", message);
@@ -475,6 +647,17 @@ function App() {
       membershipStatus: member.membershipStatus,
       joinDate: member.joinDate,
     });
+
+    setCreateSubscriptionState((currentState) => ({
+      ...currentState,
+      memberId: member.id,
+    }));
+
+    setCreateVisitState((currentState) => ({
+      ...currentState,
+      memberId: member.id,
+    }));
+
     setResponseOutput(JSON.stringify(member, null, 2));
   };
 
@@ -522,6 +705,11 @@ function App() {
 
       setResponseOutput(JSON.stringify(updateMemberResponse, null, 2));
       await loadMembers();
+
+      if (adminDashboard) {
+        await loadDashboard();
+      }
+
       showToast("success", "Member updated");
     } catch (error) {
       const message =
@@ -575,6 +763,10 @@ function App() {
       setResponseOutput(JSON.stringify(deleteResponse, null, 2));
       await loadMembers();
 
+      if (adminDashboard) {
+        await loadDashboard();
+      }
+
       if (updateMemberState.memberId === memberPendingDeletion.id) {
         handleClearUpdateForm();
       }
@@ -612,6 +804,26 @@ function App() {
     fieldValue: string,
   ) => {
     setUpdateMemberState((currentState) => ({
+      ...currentState,
+      [fieldName]: fieldValue,
+    }));
+  };
+
+  const updateCreateSubscriptionState = (
+    fieldName: keyof SubscriptionInput,
+    fieldValue: string | number | boolean,
+  ) => {
+    setCreateSubscriptionState((currentState) => ({
+      ...currentState,
+      [fieldName]: fieldValue,
+    }));
+  };
+
+  const updateCreateVisitState = (
+    fieldName: keyof VisitInput,
+    fieldValue: string,
+  ) => {
+    setCreateVisitState((currentState) => ({
       ...currentState,
       [fieldName]: fieldValue,
     }));
@@ -689,8 +901,8 @@ function App() {
               <h1>Gym Membership API</h1>
               <p className="heroText">
                 Firebase login, admin authorization, member creation, editing,
-                deletion, inactive-member reminders, and expiring-subscription
-                reminders in one clean interface.
+                deletion, inactive-member reminders, expiring-subscription
+                reminders, plus quick forms for subscriptions and visits.
               </p>
             </div>
 
@@ -1029,11 +1241,7 @@ function App() {
                             <strong>
                               {subscription.firstName} {subscription.lastName}
                             </strong>
-                            <span
-                              className={`memberBadge memberBadge-${
-                                subscription.isActive ? "active" : "inactive"
-                              }`}
-                            >
+                            <span className="memberBadge memberBadge-active">
                               {subscription.planName}
                             </span>
                           </div>
@@ -1089,7 +1297,8 @@ function App() {
                     Members <span className="countBadge">{members.length}</span>
                   </h2>
                   <p className="mutedText">
-                    Click a member to load their data into the edit form.
+                    Click a member to load their data into the edit form and test
+                    forms below.
                   </p>
                 </div>
 
@@ -1510,6 +1719,208 @@ function App() {
                     <span>Delete</span>
                   </button>
                 </div>
+              </section>
+            </div>
+
+            <div className="formRow">
+              <section className="panel">
+                <h2>Create Subscription</h2>
+                <p className="mutedText">
+                  Use this to test expiring subscriptions and reminder emails.
+                </p>
+
+                <div className="formGrid">
+                  <label>
+                    Member
+                    <select
+                      value={createSubscriptionState.memberId}
+                      onChange={(event) =>
+                        updateCreateSubscriptionState("memberId", event.target.value)
+                      }
+                    >
+                      <option value="">Select member</option>
+                      {members.map((member) => (
+                        <option key={member.id} value={member.id}>
+                          {member.firstName} {member.lastName}
+                        </option>
+                      ))}
+                    </select>
+                  </label>
+
+                  <label>
+                    Plan Name
+                    <input
+                      value={createSubscriptionState.planName}
+                      onChange={(event) =>
+                        updateCreateSubscriptionState("planName", event.target.value)
+                      }
+                    />
+                  </label>
+
+                  <label>
+                    Start Date
+                    <input
+                      type="date"
+                      value={toDateInputValue(createSubscriptionState.startDate)}
+                      onChange={(event) =>
+                        updateCreateSubscriptionState(
+                          "startDate",
+                          fromDateInputValue(event.target.value),
+                        )
+                      }
+                    />
+                  </label>
+
+                  <label>
+                    End Date
+                    <input
+                      type="date"
+                      value={toDateInputValue(createSubscriptionState.endDate)}
+                      onChange={(event) =>
+                        updateCreateSubscriptionState(
+                          "endDate",
+                          fromDateInputValue(event.target.value),
+                        )
+                      }
+                    />
+                  </label>
+
+                  <label>
+                    Price
+                    <input
+                      type="number"
+                      min="0"
+                      step="0.01"
+                      value={createSubscriptionState.price}
+                      onChange={(event) =>
+                        updateCreateSubscriptionState(
+                          "price",
+                          Number(event.target.value),
+                        )
+                      }
+                    />
+                  </label>
+
+                  <label>
+                    Payment Status
+                    <select
+                      value={createSubscriptionState.paymentStatus}
+                      onChange={(event) =>
+                        updateCreateSubscriptionState(
+                          "paymentStatus",
+                          event.target.value,
+                        )
+                      }
+                    >
+                      <option value="paid">Paid</option>
+                      <option value="unpaid">Unpaid</option>
+                      <option value="overdue">Overdue</option>
+                    </select>
+                  </label>
+
+                  <label>
+                    Is Active
+                    <select
+                      value={createSubscriptionState.isActive ? "true" : "false"}
+                      onChange={(event) =>
+                        updateCreateSubscriptionState(
+                          "isActive",
+                          event.target.value === "true",
+                        )
+                      }
+                    >
+                      <option value="true">True</option>
+                      <option value="false">False</option>
+                    </select>
+                  </label>
+                </div>
+
+                <button
+                  onClick={handleCreateSubscription}
+                  disabled={isLoading || !idToken}
+                >
+                  {isLoading ? "Creating..." : "Create Subscription"}
+                </button>
+              </section>
+
+              <section className="panel">
+                <h2>Create Visit</h2>
+                <p className="mutedText">
+                  Use this to test inactive members and reminder emails.
+                </p>
+
+                <div className="formGrid">
+                  <label>
+                    Member
+                    <select
+                      value={createVisitState.memberId}
+                      onChange={(event) =>
+                        updateCreateVisitState("memberId", event.target.value)
+                      }
+                    >
+                      <option value="">Select member</option>
+                      {members.map((member) => (
+                        <option key={member.id} value={member.id}>
+                          {member.firstName} {member.lastName}
+                        </option>
+                      ))}
+                    </select>
+                  </label>
+
+                  <label>
+                    Visit Date
+                    <input
+                      type="date"
+                      value={toDateInputValue(createVisitState.visitDate)}
+                      onChange={(event) =>
+                        updateCreateVisitState(
+                          "visitDate",
+                          fromDateInputValue(event.target.value),
+                        )
+                      }
+                    />
+                  </label>
+
+                  <label>
+                    Check In Time
+                    <input
+                      type="time"
+                      value={createVisitState.checkInTime}
+                      onChange={(event) =>
+                        updateCreateVisitState("checkInTime", event.target.value)
+                      }
+                    />
+                  </label>
+
+                  <label>
+                    Check Out Time
+                    <input
+                      type="time"
+                      value={createVisitState.checkOutTime}
+                      onChange={(event) =>
+                        updateCreateVisitState("checkOutTime", event.target.value)
+                      }
+                    />
+                  </label>
+
+                  <label className="formGridSingle">
+                    Notes
+                    <textarea
+                      rows={4}
+                      value={createVisitState.notes}
+                      onChange={(event) =>
+                        updateCreateVisitState("notes", event.target.value)
+                      }
+                    />
+                  </label>
+                </div>
+
+                <button
+                  onClick={handleCreateVisit}
+                  disabled={isLoading || !idToken}
+                >
+                  {isLoading ? "Creating..." : "Create Visit"}
+                </button>
               </section>
             </div>
           </main>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,12 +3,15 @@ import {
   createMember,
   deleteMember,
   getAdminDashboard,
+  getExpiringSubscriptions,
   getInactiveMembers,
   getMembers,
   loginWithFirebase,
+  sendExpiringSubscriptionReminder,
   sendInactiveMemberReminder,
   updateMember,
   type AdminDashboardResponse,
+  type ExpiringSubscriptionsResponse,
   type InactiveMembersResponse,
   type Member,
   type MemberInput,
@@ -174,6 +177,8 @@ function App() {
   >(null);
   const [inactiveMembersData, setInactiveMembersData] =
     useState<InactiveMembersResponse | null>(null);
+  const [expiringSubscriptionsData, setExpiringSubscriptionsData] =
+    useState<ExpiringSubscriptionsResponse | null>(null);
   const [createMemberState, setCreateMemberState] = useState<MemberInput>(
     initialCreateMemberState,
   );
@@ -256,6 +261,7 @@ function App() {
     setMembers([]);
     setAdminDashboard(null);
     setInactiveMembersData(null);
+    setExpiringSubscriptionsData(null);
     setSelectedMemberId("");
     setUpdateMemberState(initialUpdateMemberState);
     showToast("success", "Signed out");
@@ -336,6 +342,66 @@ function App() {
         error instanceof Error
           ? error.message
           : "Inactive reminder request failed";
+
+      setResponseOutput(JSON.stringify({ message }, null, 2));
+      showToast("error", message);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleLoadExpiringSubscriptions = async () => {
+    if (!idToken) {
+      const message = "No token available. Please log in first.";
+      setResponseOutput(message);
+      showToast("error", message);
+      return;
+    }
+
+    setIsLoading(true);
+
+    try {
+      const expiringSubscriptionsResponse = await getExpiringSubscriptions(idToken);
+      setExpiringSubscriptionsData(expiringSubscriptionsResponse);
+      setResponseOutput(JSON.stringify(expiringSubscriptionsResponse, null, 2));
+      showToast("success", "Expiring subscriptions loaded");
+    } catch (error) {
+      const message =
+        error instanceof Error
+          ? error.message
+          : "Expiring subscriptions request failed";
+
+      setResponseOutput(JSON.stringify({ message }, null, 2));
+      showToast("error", message);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleSendExpiringSubscriptionReminder = async (
+    subscriptionId: string,
+  ) => {
+    if (!idToken) {
+      const message = "Admin login is required.";
+      setResponseOutput(JSON.stringify({ message }, null, 2));
+      showToast("error", message);
+      return;
+    }
+
+    setIsLoading(true);
+
+    try {
+      const reminderResponse = await sendExpiringSubscriptionReminder(
+        idToken,
+        subscriptionId,
+      );
+      setResponseOutput(JSON.stringify(reminderResponse, null, 2));
+      showToast("success", "Subscription reminder sent");
+    } catch (error) {
+      const message =
+        error instanceof Error
+          ? error.message
+          : "Subscription reminder request failed";
 
       setResponseOutput(JSON.stringify({ message }, null, 2));
       showToast("error", message);
@@ -623,7 +689,8 @@ function App() {
               <h1>Gym Membership API</h1>
               <p className="heroText">
                 Firebase login, admin authorization, member creation, editing,
-                deletion, and inactive-member reminders in one clean interface.
+                deletion, inactive-member reminders, and expiring-subscription
+                reminders in one clean interface.
               </p>
             </div>
 
@@ -738,6 +805,13 @@ function App() {
                   disabled={isLoading || !idToken}
                 >
                   Load Inactive Members
+                </button>
+                <button
+                  className="secondary"
+                  onClick={handleLoadExpiringSubscriptions}
+                  disabled={isLoading || !idToken}
+                >
+                  Load Expiring Subscriptions
                 </button>
               </div>
             </section>
@@ -912,6 +986,97 @@ function App() {
                   </p>
                   <p className="mutedText">
                     Click <code>Load Inactive Members</code>.
+                  </p>
+                </div>
+              )}
+            </section>
+
+            <section className="panel">
+              <div className="sectionHeader">
+                <div>
+                  <h2>
+                    Expiring Subscriptions{" "}
+                    <span className="countBadge">
+                      {expiringSubscriptionsData?.totalExpiringSubscriptions ?? 0}
+                    </span>
+                  </h2>
+                  <p className="mutedText">
+                    Active subscriptions ending within{" "}
+                    <code>{expiringSubscriptionsData?.thresholdDays ?? 7}</code>{" "}
+                    days.
+                  </p>
+                </div>
+              </div>
+
+              {expiringSubscriptionsData ? (
+                expiringSubscriptionsData.subscriptions.length > 0 ? (
+                  <div className="memberList">
+                    {expiringSubscriptionsData.subscriptions.map((subscription) => (
+                      <div key={subscription.subscriptionId} className="memberCard">
+                        <div
+                          className="memberAvatar"
+                          style={{
+                            backgroundColor: getAvatarColor(
+                              `${subscription.firstName}${subscription.lastName}${subscription.subscriptionId}`,
+                            ),
+                          }}
+                        >
+                          {getInitials(subscription.firstName, subscription.lastName)}
+                        </div>
+
+                        <div className="memberInfo">
+                          <div className="memberCardTop">
+                            <strong>
+                              {subscription.firstName} {subscription.lastName}
+                            </strong>
+                            <span
+                              className={`memberBadge memberBadge-${
+                                subscription.isActive ? "active" : "inactive"
+                              }`}
+                            >
+                              {subscription.planName}
+                            </span>
+                          </div>
+
+                          <span className="memberEmail">{subscription.email}</span>
+
+                          <small className="memberId">
+                            Ends on {toDateInputValue(subscription.endDate)} ·{" "}
+                            {subscription.daysUntilEnd} day(s) left ·{" "}
+                            {subscription.paymentStatus}
+                          </small>
+
+                          <div className="actionGroup">
+                            <button
+                              className="secondary"
+                              onClick={() =>
+                                handleSendExpiringSubscriptionReminder(
+                                  subscription.subscriptionId,
+                                )
+                              }
+                              disabled={isLoading || !idToken}
+                            >
+                              Send Reminder
+                            </button>
+                          </div>
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                ) : (
+                  <div className="emptyState">
+                    <p>
+                      <strong>No expiring subscriptions found.</strong>
+                    </p>
+                  </div>
+                )
+              ) : (
+                <div className="emptyState">
+                  <p>
+                    <strong>Expiring subscriptions not loaded yet.</strong>
+                  </p>
+                  <p className="mutedText">
+                    Click <code>Load Expiring Subscriptions</code>.
                   </p>
                 </div>
               )}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -36,45 +36,75 @@ const initialUpdateMemberState = {
   joinDate: "",
 };
 
-// --- helpers -----------------------------------------------------------------
-
 const getInitials = (firstName: string, lastName: string) =>
   `${firstName.charAt(0)}${lastName.charAt(0)}`.toUpperCase() || "?";
 
 const getAvatarColor = (seed: string) => {
   const palette = [
-    "#2563eb", "#7c3aed", "#db2777", "#16a34a",
-    "#ea580c", "#0891b2", "#dc2626", "#4f46e5",
+    "#2563eb",
+    "#7c3aed",
+    "#db2777",
+    "#16a34a",
+    "#ea580c",
+    "#0891b2",
+    "#dc2626",
+    "#4f46e5",
   ];
+
   let hash = 0;
-  for (let i = 0; i < seed.length; i += 1) {
-    hash = seed.charCodeAt(i) + ((hash << 5) - hash);
+
+  for (let index = 0; index < seed.length; index += 1) {
+    hash = seed.charCodeAt(index) + ((hash << 5) - hash);
   }
+
   return palette[Math.abs(hash) % palette.length];
 };
 
 const toDateInputValue = (isoString: string) => {
-  if (!isoString) return "";
+  if (!isoString) {
+    return "";
+  }
+
   const date = new Date(isoString);
-  if (Number.isNaN(date.getTime())) return "";
+
+  if (Number.isNaN(date.getTime())) {
+    return "";
+  }
+
   return date.toISOString().split("T")[0];
 };
 
 const fromDateInputValue = (dateString: string) => {
-  if (!dateString) return "";
+  if (!dateString) {
+    return "";
+  }
+
   const date = new Date(dateString);
-  if (Number.isNaN(date.getTime())) return "";
+
+  if (Number.isNaN(date.getTime())) {
+    return "";
+  }
+
   return date.toISOString();
 };
 
 type Theme = "light" | "dark";
+
 const THEME_STORAGE_KEY = "gym-api-theme";
 
 const getInitialTheme = (): Theme => {
-  if (typeof window === "undefined") return "light";
-  const stored = window.localStorage.getItem(THEME_STORAGE_KEY);
-  if (stored === "light" || stored === "dark") return stored;
+  if (typeof window === "undefined") {
+    return "light";
+  }
+
+  const storedTheme = window.localStorage.getItem(THEME_STORAGE_KEY);
+
+  if (storedTheme === "light" || storedTheme === "dark") {
+    return storedTheme;
+  }
+
   const prefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
+
   return prefersDark ? "dark" : "light";
 };
 
@@ -84,20 +114,43 @@ interface ToastState {
 }
 
 const SunIcon = () => (
-  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+  >
     <circle cx="12" cy="12" r="4" />
     <path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41" />
   </svg>
 );
 
 const MoonIcon = () => (
-  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+  >
     <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" />
   </svg>
 );
 
 const TrashIcon = () => (
-  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" width="16" height="16">
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    width="16"
+    height="16"
+  >
     <path d="M3 6h18M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2m3 0v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6h14zM10 11v6M14 11v6" />
   </svg>
 );
@@ -112,12 +165,17 @@ function App() {
   const [members, setMembers] = useState<Member[]>([]);
   const [searchQuery, setSearchQuery] = useState("");
   const [selectedMemberId, setSelectedMemberId] = useState("");
-  const [createMemberState, setCreateMemberState] = useState<MemberInput>(initialCreateMemberState);
-  const [updateMemberState, setUpdateMemberState] = useState(initialUpdateMemberState);
+  const [createMemberState, setCreateMemberState] = useState<MemberInput>(
+    initialCreateMemberState,
+  );
+  const [updateMemberState, setUpdateMemberState] = useState(
+    initialUpdateMemberState,
+  );
   const [isLoading, setIsLoading] = useState(false);
   const [toast, setToast] = useState<ToastState | null>(null);
   const [theme, setTheme] = useState<Theme>(getInitialTheme);
-  const [memberPendingDeletion, setMemberPendingDeletion] = useState<Member | null>(null);
+  const [memberPendingDeletion, setMemberPendingDeletion] =
+    useState<Member | null>(null);
   const [isDeleting, setIsDeleting] = useState(false);
 
   useEffect(() => {
@@ -125,7 +183,9 @@ function App() {
     window.localStorage.setItem(THEME_STORAGE_KEY, theme);
   }, [theme]);
 
-  const toggleTheme = () => setTheme((c) => (c === "light" ? "dark" : "light"));
+  const toggleTheme = () => {
+    setTheme((currentTheme) => (currentTheme === "light" ? "dark" : "light"));
+  };
 
   const showToast = (type: ToastState["type"], message: string) => {
     setToast({ type, message });
@@ -133,11 +193,18 @@ function App() {
   };
 
   const loadMembers = async () => {
+    if (!idToken) {
+      setMembers([]);
+      return;
+    }
+
     try {
-      const memberList = await getMembers();
+      const memberList = await getMembers(idToken);
       setMembers(memberList);
     } catch (error) {
-      const message = error instanceof Error ? error.message : "Failed to load members";
+      const message =
+        error instanceof Error ? error.message : "Failed to load members";
+      setMembers([]);
       setResponseOutput(JSON.stringify({ message }, null, 2));
       showToast("error", message);
     }
@@ -145,13 +212,18 @@ function App() {
 
   useEffect(() => {
     void loadMembers();
-  }, []);
+  }, [idToken]);
 
   const handleLogin = async () => {
     setIsLoading(true);
     setAuthMessage("Logging in...");
+
     try {
-      const loginResponse = await loginWithFirebase({ email: loginEmail, password: loginPassword });
+      const loginResponse = await loginWithFirebase({
+        email: loginEmail,
+        password: loginPassword,
+      });
+
       setIdToken(loginResponse.idToken);
       setSignedInEmail(loginResponse.email);
       setAuthMessage(`Logged in as ${loginResponse.email}`);
@@ -172,6 +244,9 @@ function App() {
     setAuthMessage("Not logged in");
     setLoginEmail("");
     setLoginPassword("");
+    setMembers([]);
+    setSelectedMemberId("");
+    setUpdateMemberState(initialUpdateMemberState);
     showToast("success", "Signed out");
   };
 
@@ -182,13 +257,19 @@ function App() {
       showToast("error", message);
       return;
     }
+
     setIsLoading(true);
+
     try {
       const adminDashboardResponse = await getAdminDashboard(idToken);
       setResponseOutput(JSON.stringify(adminDashboardResponse, null, 2));
       showToast("success", "Admin dashboard loaded");
     } catch (error) {
-      const message = error instanceof Error ? error.message : "Admin dashboard request failed";
+      const message =
+        error instanceof Error
+          ? error.message
+          : "Admin dashboard request failed";
+
       setResponseOutput(JSON.stringify({ message }, null, 2));
       showToast("error", message);
     } finally {
@@ -197,15 +278,27 @@ function App() {
   };
 
   const handleCreateMember = async () => {
+    if (!idToken) {
+      const message = "Admin login is required.";
+      setResponseOutput(JSON.stringify({ message }, null, 2));
+      showToast("error", message);
+      return;
+    }
+
     setIsLoading(true);
+
     try {
-      const createMemberResponse = await createMember(createMemberState);
+      const createMemberResponse = await createMember(idToken, createMemberState);
       setResponseOutput(JSON.stringify(createMemberResponse, null, 2));
       await loadMembers();
+
       showToast(
         "success",
-        `Created ${createMemberResponse.firstName ?? "member"} ${createMemberResponse.lastName ?? ""}`.trim(),
+        `Created ${createMemberResponse.firstName ?? "member"} ${
+          createMemberResponse.lastName ?? ""
+        }`.trim(),
       );
+
       if (createMemberResponse.id) {
         setSelectedMemberId(createMemberResponse.id);
         setUpdateMemberState({
@@ -216,13 +309,18 @@ function App() {
           phoneNumber: createMemberResponse.phoneNumber ?? "",
           dateOfBirth: createMemberResponse.dateOfBirth ?? "",
           emergencyContactName: createMemberResponse.emergencyContactName ?? "",
-          emergencyContactPhoneNumber: createMemberResponse.emergencyContactPhoneNumber ?? "",
+          emergencyContactPhoneNumber:
+            createMemberResponse.emergencyContactPhoneNumber ?? "",
           membershipStatus: createMemberResponse.membershipStatus ?? "active",
           joinDate: createMemberResponse.joinDate ?? "",
         });
       }
     } catch (error) {
-      const message = error instanceof Error ? error.message : "Create member request failed";
+      const message =
+        error instanceof Error
+          ? error.message
+          : "Create member request failed";
+
       setResponseOutput(JSON.stringify({ message }, null, 2));
       showToast("error", message);
     } finally {
@@ -253,12 +351,20 @@ function App() {
   };
 
   const handleUpdateMember = async () => {
+    if (!idToken) {
+      const message = "Admin login is required.";
+      setResponseOutput(JSON.stringify({ message }, null, 2));
+      showToast("error", message);
+      return;
+    }
+
     if (!updateMemberState.memberId.trim()) {
       const message = "Member ID is required for update";
       setResponseOutput(JSON.stringify({ message }, null, 2));
       showToast("error", message);
       return;
     }
+
     const updatePayload: Partial<MemberInput> = {
       firstName: updateMemberState.firstName,
       lastName: updateMemberState.lastName,
@@ -266,18 +372,30 @@ function App() {
       phoneNumber: updateMemberState.phoneNumber,
       dateOfBirth: updateMemberState.dateOfBirth,
       emergencyContactName: updateMemberState.emergencyContactName,
-      emergencyContactPhoneNumber: updateMemberState.emergencyContactPhoneNumber,
+      emergencyContactPhoneNumber:
+        updateMemberState.emergencyContactPhoneNumber,
       membershipStatus: updateMemberState.membershipStatus,
       joinDate: updateMemberState.joinDate,
     };
+
     setIsLoading(true);
+
     try {
-      const updateMemberResponse = await updateMember(updateMemberState.memberId, updatePayload);
+      const updateMemberResponse = await updateMember(
+        idToken,
+        updateMemberState.memberId,
+        updatePayload,
+      );
+
       setResponseOutput(JSON.stringify(updateMemberResponse, null, 2));
       await loadMembers();
       showToast("success", "Member updated");
     } catch (error) {
-      const message = error instanceof Error ? error.message : "Update member request failed";
+      const message =
+        error instanceof Error
+          ? error.message
+          : "Update member request failed";
+
       setResponseOutput(JSON.stringify({ message }, null, 2));
       showToast("error", message);
     } finally {
@@ -287,34 +405,58 @@ function App() {
 
   const requestDeleteMember = () => {
     const currentSelectedMember = members.find(
-      (m) => m.id === updateMemberState.memberId,
+      (member) => member.id === updateMemberState.memberId,
     );
-    if (!currentSelectedMember) return;
+
+    if (!currentSelectedMember) {
+      return;
+    }
+
     setMemberPendingDeletion(currentSelectedMember);
   };
 
   const cancelDeleteMember = () => {
-    if (isDeleting) return;
+    if (isDeleting) {
+      return;
+    }
+
     setMemberPendingDeletion(null);
   };
 
   const confirmDeleteMember = async () => {
-    if (!memberPendingDeletion) return;
+    if (!idToken) {
+      const message = "Admin login is required.";
+      setResponseOutput(JSON.stringify({ message }, null, 2));
+      showToast("error", message);
+      return;
+    }
+
+    if (!memberPendingDeletion) {
+      return;
+    }
+
     setIsDeleting(true);
+
     try {
-      const deleteResponse = await deleteMember(memberPendingDeletion.id);
+      const deleteResponse = await deleteMember(idToken, memberPendingDeletion.id);
       setResponseOutput(JSON.stringify(deleteResponse, null, 2));
       await loadMembers();
+
       if (updateMemberState.memberId === memberPendingDeletion.id) {
         handleClearUpdateForm();
       }
+
       showToast(
         "success",
         `Deleted ${memberPendingDeletion.firstName} ${memberPendingDeletion.lastName}`,
       );
       setMemberPendingDeletion(null);
     } catch (error) {
-      const message = error instanceof Error ? error.message : "Delete member request failed";
+      const message =
+        error instanceof Error
+          ? error.message
+          : "Delete member request failed";
+
       setResponseOutput(JSON.stringify({ message }, null, 2));
       showToast("error", message);
     } finally {
@@ -322,22 +464,34 @@ function App() {
     }
   };
 
-  const updateCreateMemberState = (fieldName: keyof MemberInput, fieldValue: string) => {
-    setCreateMemberState((s) => ({ ...s, [fieldName]: fieldValue }));
+  const updateCreateMemberState = (
+    fieldName: keyof MemberInput,
+    fieldValue: string,
+  ) => {
+    setCreateMemberState((currentState) => ({
+      ...currentState,
+      [fieldName]: fieldValue,
+    }));
   };
 
   const updateEditMemberState = (
     fieldName: keyof typeof initialUpdateMemberState,
     fieldValue: string,
   ) => {
-    setUpdateMemberState((s) => ({ ...s, [fieldName]: fieldValue }));
+    setUpdateMemberState((currentState) => ({
+      ...currentState,
+      [fieldName]: fieldValue,
+    }));
   };
 
   const normalizedSearchQuery = searchQuery.trim().toLowerCase();
+
   const filteredMembers = normalizedSearchQuery
     ? members.filter(
         (member) =>
-          `${member.firstName} ${member.lastName}`.toLowerCase().includes(normalizedSearchQuery) ||
+          `${member.firstName} ${member.lastName}`
+            .toLowerCase()
+            .includes(normalizedSearchQuery) ||
           member.email.toLowerCase().includes(normalizedSearchQuery),
       )
     : members;
@@ -354,10 +508,14 @@ function App() {
       ) : null}
 
       {memberPendingDeletion ? (
-        <div className="modalOverlay" onClick={cancelDeleteMember} role="presentation">
+        <div
+          className="modalOverlay"
+          onClick={cancelDeleteMember}
+          role="presentation"
+        >
           <div
             className="modalContent"
-            onClick={(e) => e.stopPropagation()}
+            onClick={(event) => event.stopPropagation()}
             role="dialog"
             aria-modal="true"
             aria-labelledby="delete-dialog-title"
@@ -371,10 +529,18 @@ function App() {
               . This action cannot be undone.
             </p>
             <div className="modalActions">
-              <button className="secondary" onClick={cancelDeleteMember} disabled={isDeleting}>
+              <button
+                className="secondary"
+                onClick={cancelDeleteMember}
+                disabled={isDeleting}
+              >
                 Cancel
               </button>
-              <button className="danger" onClick={confirmDeleteMember} disabled={isDeleting}>
+              <button
+                className="danger"
+                onClick={confirmDeleteMember}
+                disabled={isDeleting}
+              >
                 {isDeleting ? "Deleting..." : "Delete"}
               </button>
             </div>
@@ -386,13 +552,14 @@ function App() {
         <header className="hero">
           <div className="heroContent">
             <div>
-              <p className="eyebrow">Frontend </p>
+              <p className="eyebrow">Frontend</p>
               <h1>Gym Membership API</h1>
               <p className="heroText">
-                Firebase login, admin authorization, member creation, editing, and deletion in one
-                clean interface.
+                Firebase login, admin authorization, member creation, editing,
+                and deletion in one clean interface.
               </p>
             </div>
+
             <div className="heroActions">
               <div
                 className={`heroStatus ${idToken ? "heroStatusActive" : ""}`}
@@ -401,12 +568,21 @@ function App() {
                 <span className="statusDot" />
                 {idToken ? `Signed in · ${signedInEmail}` : "Not authenticated"}
               </div>
+
               <button
                 type="button"
                 className="themeToggle"
                 onClick={toggleTheme}
-                aria-label={theme === "dark" ? "Switch to light mode" : "Switch to dark mode"}
-                title={theme === "dark" ? "Switch to light mode" : "Switch to dark mode"}
+                aria-label={
+                  theme === "dark"
+                    ? "Switch to light mode"
+                    : "Switch to dark mode"
+                }
+                title={
+                  theme === "dark"
+                    ? "Switch to light mode"
+                    : "Switch to dark mode"
+                }
               >
                 {theme === "dark" ? <SunIcon /> : <MoonIcon />}
               </button>
@@ -418,6 +594,7 @@ function App() {
           <aside className="sidebar">
             <section className="panel">
               <h2>Login</h2>
+
               {idToken ? (
                 <>
                   <div className="statusBox">
@@ -427,6 +604,7 @@ function App() {
                       {signedInEmail}
                     </p>
                   </div>
+
                   <button
                     className="secondary"
                     onClick={handleLogout}
@@ -444,23 +622,31 @@ function App() {
                       <input
                         type="email"
                         value={loginEmail}
-                        onChange={(e) => setLoginEmail(e.target.value)}
+                        onChange={(event) => setLoginEmail(event.target.value)}
                         placeholder="user@gmail.com"
                       />
                     </label>
+
                     <label>
                       Password
                       <input
                         type="password"
                         value={loginPassword}
-                        onChange={(e) => setLoginPassword(e.target.value)}
+                        onChange={(event) =>
+                          setLoginPassword(event.target.value)
+                        }
                         placeholder="Enter password"
                       />
                     </label>
                   </div>
-                  <button onClick={handleLogin} disabled={isLoading || !loginEmail || !loginPassword}>
+
+                  <button
+                    onClick={handleLogin}
+                    disabled={isLoading || !loginEmail || !loginPassword}
+                  >
                     {isLoading ? "Signing in..." : "Log In"}
                   </button>
+
                   <div className="statusBox">
                     <p>
                       <strong>Status:</strong> {authMessage}
@@ -473,7 +659,10 @@ function App() {
             <section className="panel">
               <h2>Admin Dashboard</h2>
               <p className="mutedText">Test admin-only access after login.</p>
-              <button onClick={handleAdminDashboardRequest} disabled={isLoading || !idToken}>
+              <button
+                onClick={handleAdminDashboardRequest}
+                disabled={isLoading || !idToken}
+              >
                 Call Admin Dashboard
               </button>
             </section>
@@ -493,7 +682,10 @@ function App() {
                   </button>
                 ) : null}
               </div>
-              <pre>{responseOutput || "No response yet. Trigger an API call above."}</pre>
+
+              <pre>
+                {responseOutput || "No response yet. Trigger an API call above."}
+              </pre>
             </section>
           </aside>
 
@@ -504,9 +696,16 @@ function App() {
                   <h2>
                     Members <span className="countBadge">{members.length}</span>
                   </h2>
-                  <p className="mutedText">Click a member to load their data into the edit form.</p>
+                  <p className="mutedText">
+                    Click a member to load their data into the edit form.
+                  </p>
                 </div>
-                <button className="secondary" onClick={() => void loadMembers()} disabled={isLoading}>
+
+                <button
+                  className="secondary"
+                  onClick={() => void loadMembers()}
+                  disabled={isLoading || !idToken}
+                >
                   {isLoading ? "Loading..." : "Refresh"}
                 </button>
               </div>
@@ -515,59 +714,76 @@ function App() {
                 <input
                   type="search"
                   value={searchQuery}
-                  onChange={(e) => setSearchQuery(e.target.value)}
+                  onChange={(event) => setSearchQuery(event.target.value)}
                   placeholder="Search by name or email..."
+                  disabled={!idToken}
                 />
               </div>
 
               <div className="memberList">
-                {filteredMembers.map((member) => (
-                  <button
-                    key={member.id}
-                    className={`memberCard ${
-                      selectedMemberId === member.id ? "memberCardActive" : ""
-                    }`}
-                    onClick={() => handleSelectMember(member)}
-                  >
-                    <div
-                      className="memberAvatar"
-                      style={{
-                        backgroundColor: getAvatarColor(
-                          `${member.firstName}${member.lastName}${member.id}`,
-                        ),
-                      }}
-                    >
-                      {getInitials(member.firstName, member.lastName)}
-                    </div>
-                    <div className="memberInfo">
-                      <div className="memberCardTop">
-                        <strong>
-                          {member.firstName} {member.lastName}
-                        </strong>
-                        <span className={`memberBadge memberBadge-${member.membershipStatus}`}>
-                          {member.membershipStatus}
-                        </span>
-                      </div>
-                      <span className="memberEmail">{member.email}</span>
-                      <small className="memberId" title={member.id}>
-                        ID: {member.id}
-                      </small>
-                    </div>
-                  </button>
-                ))}
+                {!idToken ? (
+                  <div className="emptyState">
+                    <p>
+                      <strong>Login required.</strong>
+                    </p>
+                    <p className="mutedText">
+                      Sign in as an admin to load members.
+                    </p>
+                  </div>
+                ) : null}
 
-                {members.length === 0 ? (
+                {idToken &&
+                  filteredMembers.map((member) => (
+                    <button
+                      key={member.id}
+                      className={`memberCard ${
+                        selectedMemberId === member.id ? "memberCardActive" : ""
+                      }`}
+                      onClick={() => handleSelectMember(member)}
+                    >
+                      <div
+                        className="memberAvatar"
+                        style={{
+                          backgroundColor: getAvatarColor(
+                            `${member.firstName}${member.lastName}${member.id}`,
+                          ),
+                        }}
+                      >
+                        {getInitials(member.firstName, member.lastName)}
+                      </div>
+
+                      <div className="memberInfo">
+                        <div className="memberCardTop">
+                          <strong>
+                            {member.firstName} {member.lastName}
+                          </strong>
+                          <span
+                            className={`memberBadge memberBadge-${member.membershipStatus}`}
+                          >
+                            {member.membershipStatus}
+                          </span>
+                        </div>
+
+                        <span className="memberEmail">{member.email}</span>
+                        <small className="memberId" title={member.id}>
+                          ID: {member.id}
+                        </small>
+                      </div>
+                    </button>
+                  ))}
+
+                {idToken && members.length === 0 ? (
                   <div className="emptyState">
                     <p>
                       <strong>No members yet.</strong>
                     </p>
                     <p className="mutedText">
-                      Run <code>node scripts/seed.js</code> to populate demo data.
+                      Create the first member using the form below.
                     </p>
                   </div>
                 ) : null}
 
-                {members.length > 0 && filteredMembers.length === 0 ? (
+                {idToken && members.length > 0 && filteredMembers.length === 0 ? (
                   <div className="emptyState">
                     <p>
                       No members match "<strong>{searchQuery}</strong>".
@@ -580,6 +796,7 @@ function App() {
             <div className="formRow">
               <section className="panel">
                 <h2>Create Member</h2>
+                <p className="mutedText">Admin login is required.</p>
 
                 <p className="fieldGroupLabel">Personal Info</p>
                 <div className="formGrid">
@@ -587,24 +804,33 @@ function App() {
                     First Name
                     <input
                       value={createMemberState.firstName}
-                      onChange={(e) => updateCreateMemberState("firstName", e.target.value)}
+                      onChange={(event) =>
+                        updateCreateMemberState("firstName", event.target.value)
+                      }
                     />
                   </label>
+
                   <label>
                     Last Name
                     <input
                       value={createMemberState.lastName}
-                      onChange={(e) => updateCreateMemberState("lastName", e.target.value)}
+                      onChange={(event) =>
+                        updateCreateMemberState("lastName", event.target.value)
+                      }
                     />
                   </label>
+
                   <label>
                     Date of Birth
                     <input
                       type="date"
                       max={new Date().toISOString().split("T")[0]}
                       value={toDateInputValue(createMemberState.dateOfBirth)}
-                      onChange={(e) =>
-                        updateCreateMemberState("dateOfBirth", fromDateInputValue(e.target.value))
+                      onChange={(event) =>
+                        updateCreateMemberState(
+                          "dateOfBirth",
+                          fromDateInputValue(event.target.value),
+                        )
                       }
                     />
                   </label>
@@ -617,15 +843,20 @@ function App() {
                     <input
                       type="email"
                       value={createMemberState.email}
-                      onChange={(e) => updateCreateMemberState("email", e.target.value)}
+                      onChange={(event) =>
+                        updateCreateMemberState("email", event.target.value)
+                      }
                     />
                   </label>
+
                   <label>
                     Phone Number
                     <input
                       type="tel"
                       value={createMemberState.phoneNumber}
-                      onChange={(e) => updateCreateMemberState("phoneNumber", e.target.value)}
+                      onChange={(event) =>
+                        updateCreateMemberState("phoneNumber", event.target.value)
+                      }
                     />
                   </label>
                 </div>
@@ -636,18 +867,25 @@ function App() {
                     Name
                     <input
                       value={createMemberState.emergencyContactName}
-                      onChange={(e) =>
-                        updateCreateMemberState("emergencyContactName", e.target.value)
+                      onChange={(event) =>
+                        updateCreateMemberState(
+                          "emergencyContactName",
+                          event.target.value,
+                        )
                       }
                     />
                   </label>
+
                   <label>
                     Phone Number
                     <input
                       type="tel"
                       value={createMemberState.emergencyContactPhoneNumber}
-                      onChange={(e) =>
-                        updateCreateMemberState("emergencyContactPhoneNumber", e.target.value)
+                      onChange={(event) =>
+                        updateCreateMemberState(
+                          "emergencyContactPhoneNumber",
+                          event.target.value,
+                        )
                       }
                     />
                   </label>
@@ -659,10 +897,10 @@ function App() {
                     Status
                     <select
                       value={createMemberState.membershipStatus}
-                      onChange={(e) =>
+                      onChange={(event) =>
                         updateCreateMemberState(
                           "membershipStatus",
-                          e.target.value as MemberInput["membershipStatus"],
+                          event.target.value as MemberInput["membershipStatus"],
                         )
                       }
                     >
@@ -671,35 +909,53 @@ function App() {
                       <option value="suspended">Suspended</option>
                     </select>
                   </label>
+
                   <label>
                     Join Date
                     <input
                       type="date"
                       value={toDateInputValue(createMemberState.joinDate)}
-                      onChange={(e) =>
-                        updateCreateMemberState("joinDate", fromDateInputValue(e.target.value))
+                      onChange={(event) =>
+                        updateCreateMemberState(
+                          "joinDate",
+                          fromDateInputValue(event.target.value),
+                        )
                       }
                     />
                   </label>
                 </div>
 
-                <button onClick={handleCreateMember} disabled={isLoading}>
+                <button
+                  onClick={handleCreateMember}
+                  disabled={isLoading || !idToken}
+                >
                   {isLoading ? "Creating..." : "Create Member"}
                 </button>
               </section>
 
               <section className="panel">
                 <div className="sectionHeader">
-                  <h2>{updateMemberState.memberId ? "Edit Member" : "Update Member"}</h2>
+                  <h2>
+                    {updateMemberState.memberId ? "Edit Member" : "Update Member"}
+                  </h2>
+
                   {updateMemberState.memberId ? (
-                    <button className="ghost" onClick={handleClearUpdateForm} disabled={isLoading}>
+                    <button
+                      className="ghost"
+                      onClick={handleClearUpdateForm}
+                      disabled={isLoading}
+                    >
                       Clear
                     </button>
                   ) : null}
                 </div>
 
+                <p className="mutedText">Admin login is required.</p>
+
                 {!updateMemberState.memberId ? (
-                  <p className="mutedText">Select a member from the list above to edit.</p>
+                  <p className="mutedText">
+                    Select a member from the list above to edit.
+                  </p>
                 ) : null}
 
                 <p className="fieldGroupLabel">Member ID</p>
@@ -707,7 +963,9 @@ function App() {
                   <label>
                     <input
                       value={updateMemberState.memberId}
-                      onChange={(e) => updateEditMemberState("memberId", e.target.value)}
+                      onChange={(event) =>
+                        updateEditMemberState("memberId", event.target.value)
+                      }
                       placeholder="Select member from the list"
                       readOnly
                     />
@@ -720,24 +978,33 @@ function App() {
                     First Name
                     <input
                       value={updateMemberState.firstName}
-                      onChange={(e) => updateEditMemberState("firstName", e.target.value)}
+                      onChange={(event) =>
+                        updateEditMemberState("firstName", event.target.value)
+                      }
                     />
                   </label>
+
                   <label>
                     Last Name
                     <input
                       value={updateMemberState.lastName}
-                      onChange={(e) => updateEditMemberState("lastName", e.target.value)}
+                      onChange={(event) =>
+                        updateEditMemberState("lastName", event.target.value)
+                      }
                     />
                   </label>
+
                   <label>
                     Date of Birth
                     <input
                       type="date"
                       max={new Date().toISOString().split("T")[0]}
                       value={toDateInputValue(updateMemberState.dateOfBirth)}
-                      onChange={(e) =>
-                        updateEditMemberState("dateOfBirth", fromDateInputValue(e.target.value))
+                      onChange={(event) =>
+                        updateEditMemberState(
+                          "dateOfBirth",
+                          fromDateInputValue(event.target.value),
+                        )
                       }
                     />
                   </label>
@@ -750,15 +1017,20 @@ function App() {
                     <input
                       type="email"
                       value={updateMemberState.email}
-                      onChange={(e) => updateEditMemberState("email", e.target.value)}
+                      onChange={(event) =>
+                        updateEditMemberState("email", event.target.value)
+                      }
                     />
                   </label>
+
                   <label>
                     Phone Number
                     <input
                       type="tel"
                       value={updateMemberState.phoneNumber}
-                      onChange={(e) => updateEditMemberState("phoneNumber", e.target.value)}
+                      onChange={(event) =>
+                        updateEditMemberState("phoneNumber", event.target.value)
+                      }
                     />
                   </label>
                 </div>
@@ -769,18 +1041,25 @@ function App() {
                     Name
                     <input
                       value={updateMemberState.emergencyContactName}
-                      onChange={(e) =>
-                        updateEditMemberState("emergencyContactName", e.target.value)
+                      onChange={(event) =>
+                        updateEditMemberState(
+                          "emergencyContactName",
+                          event.target.value,
+                        )
                       }
                     />
                   </label>
+
                   <label>
                     Phone Number
                     <input
                       type="tel"
                       value={updateMemberState.emergencyContactPhoneNumber}
-                      onChange={(e) =>
-                        updateEditMemberState("emergencyContactPhoneNumber", e.target.value)
+                      onChange={(event) =>
+                        updateEditMemberState(
+                          "emergencyContactPhoneNumber",
+                          event.target.value,
+                        )
                       }
                     />
                   </label>
@@ -792,20 +1071,29 @@ function App() {
                     Status
                     <select
                       value={updateMemberState.membershipStatus}
-                      onChange={(e) => updateEditMemberState("membershipStatus", e.target.value)}
+                      onChange={(event) =>
+                        updateEditMemberState(
+                          "membershipStatus",
+                          event.target.value,
+                        )
+                      }
                     >
                       <option value="active">Active</option>
                       <option value="inactive">Inactive</option>
                       <option value="suspended">Suspended</option>
                     </select>
                   </label>
+
                   <label>
                     Join Date
                     <input
                       type="date"
                       value={toDateInputValue(updateMemberState.joinDate)}
-                      onChange={(e) =>
-                        updateEditMemberState("joinDate", fromDateInputValue(e.target.value))
+                      onChange={(event) =>
+                        updateEditMemberState(
+                          "joinDate",
+                          fromDateInputValue(event.target.value),
+                        )
                       }
                     />
                   </label>
@@ -814,15 +1102,16 @@ function App() {
                 <div className="actionGroup">
                   <button
                     onClick={handleUpdateMember}
-                    disabled={isLoading || !updateMemberState.memberId}
+                    disabled={isLoading || !idToken || !updateMemberState.memberId}
                   >
                     {isLoading ? "Saving..." : "Update Member"}
                   </button>
+
                   <button
                     type="button"
                     className="danger"
                     onClick={requestDeleteMember}
-                    disabled={isLoading || !updateMemberState.memberId}
+                    disabled={isLoading || !idToken || !updateMemberState.memberId}
                     aria-label="Delete member"
                   >
                     <TrashIcon />

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -6,6 +6,7 @@ import {
   getMembers,
   loginWithFirebase,
   updateMember,
+  type AdminDashboardResponse,
   type Member,
   type MemberInput,
 } from "./api";
@@ -165,6 +166,9 @@ function App() {
   const [members, setMembers] = useState<Member[]>([]);
   const [searchQuery, setSearchQuery] = useState("");
   const [selectedMemberId, setSelectedMemberId] = useState("");
+  const [adminDashboard, setAdminDashboard] = useState<
+    AdminDashboardResponse["dashboard"] | null
+  >(null);
   const [createMemberState, setCreateMemberState] = useState<MemberInput>(
     initialCreateMemberState,
   );
@@ -245,6 +249,7 @@ function App() {
     setLoginEmail("");
     setLoginPassword("");
     setMembers([]);
+    setAdminDashboard(null);
     setSelectedMemberId("");
     setUpdateMemberState(initialUpdateMemberState);
     showToast("success", "Signed out");
@@ -262,6 +267,7 @@ function App() {
 
     try {
       const adminDashboardResponse = await getAdminDashboard(idToken);
+      setAdminDashboard(adminDashboardResponse.dashboard);
       setResponseOutput(JSON.stringify(adminDashboardResponse, null, 2));
       showToast("success", "Admin dashboard loaded");
     } catch (error) {
@@ -690,6 +696,72 @@ function App() {
           </aside>
 
           <main className="mainContent">
+            <section className="panel">
+              <div className="sectionHeader">
+                <div>
+                  <h2>Dashboard Overview</h2>
+                  <p className="mutedText">
+                    Real values from the admin dashboard endpoint.
+                  </p>
+                </div>
+              </div>
+
+              {adminDashboard ? (
+                <div className="dashboardGrid">
+                  <div className="statCard">
+                    <span className="statLabel">Total Members</span>
+                    <strong className="statValue">
+                      {adminDashboard.totalMembers}
+                    </strong>
+                  </div>
+
+                  <div className="statCard">
+                    <span className="statLabel">Total Subscriptions</span>
+                    <strong className="statValue">
+                      {adminDashboard.totalSubscriptions}
+                    </strong>
+                  </div>
+
+                  <div className="statCard">
+                    <span className="statLabel">Total Visits</span>
+                    <strong className="statValue">
+                      {adminDashboard.totalVisits}
+                    </strong>
+                  </div>
+
+                  <div className="statCard">
+                    <span className="statLabel">Active Members</span>
+                    <strong className="statValue">
+                      {adminDashboard.activeMembersCount}
+                    </strong>
+                  </div>
+
+                  <div className="statCard">
+                    <span className="statLabel">Inactive Members</span>
+                    <strong className="statValue">
+                      {adminDashboard.inactiveMembersCount}
+                    </strong>
+                  </div>
+
+                  <div className="statCard">
+                    <span className="statLabel">Suspended Members</span>
+                    <strong className="statValue">
+                      {adminDashboard.suspendedMembersCount}
+                    </strong>
+                  </div>
+                </div>
+              ) : (
+                <div className="emptyState">
+                  <p>
+                    <strong>Dashboard not loaded yet.</strong>
+                  </p>
+                  <p className="mutedText">
+                    Sign in as admin and click <code>Call Admin Dashboard</code>.
+                  </p>
+                </div>
+              )}
+            </section>
+
             <section className="panel">
               <div className="sectionHeader">
                 <div>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,10 +3,13 @@ import {
   createMember,
   deleteMember,
   getAdminDashboard,
+  getInactiveMembers,
   getMembers,
   loginWithFirebase,
+  sendInactiveMemberReminder,
   updateMember,
   type AdminDashboardResponse,
+  type InactiveMembersResponse,
   type Member,
   type MemberInput,
 } from "./api";
@@ -169,6 +172,8 @@ function App() {
   const [adminDashboard, setAdminDashboard] = useState<
     AdminDashboardResponse["dashboard"] | null
   >(null);
+  const [inactiveMembersData, setInactiveMembersData] =
+    useState<InactiveMembersResponse | null>(null);
   const [createMemberState, setCreateMemberState] = useState<MemberInput>(
     initialCreateMemberState,
   );
@@ -250,6 +255,7 @@ function App() {
     setLoginPassword("");
     setMembers([]);
     setAdminDashboard(null);
+    setInactiveMembersData(null);
     setSelectedMemberId("");
     setUpdateMemberState(initialUpdateMemberState);
     showToast("success", "Signed out");
@@ -275,6 +281,61 @@ function App() {
         error instanceof Error
           ? error.message
           : "Admin dashboard request failed";
+
+      setResponseOutput(JSON.stringify({ message }, null, 2));
+      showToast("error", message);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleLoadInactiveMembers = async () => {
+    if (!idToken) {
+      const message = "No token available. Please log in first.";
+      setResponseOutput(message);
+      showToast("error", message);
+      return;
+    }
+
+    setIsLoading(true);
+
+    try {
+      const inactiveMembersResponse = await getInactiveMembers(idToken);
+      setInactiveMembersData(inactiveMembersResponse);
+      setResponseOutput(JSON.stringify(inactiveMembersResponse, null, 2));
+      showToast("success", "Inactive members loaded");
+    } catch (error) {
+      const message =
+        error instanceof Error
+          ? error.message
+          : "Inactive members request failed";
+
+      setResponseOutput(JSON.stringify({ message }, null, 2));
+      showToast("error", message);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleSendInactiveReminder = async (memberId: string) => {
+    if (!idToken) {
+      const message = "Admin login is required.";
+      setResponseOutput(JSON.stringify({ message }, null, 2));
+      showToast("error", message);
+      return;
+    }
+
+    setIsLoading(true);
+
+    try {
+      const reminderResponse = await sendInactiveMemberReminder(idToken, memberId);
+      setResponseOutput(JSON.stringify(reminderResponse, null, 2));
+      showToast("success", "Inactive member reminder sent");
+    } catch (error) {
+      const message =
+        error instanceof Error
+          ? error.message
+          : "Inactive reminder request failed";
 
       setResponseOutput(JSON.stringify({ message }, null, 2));
       showToast("error", message);
@@ -562,7 +623,7 @@ function App() {
               <h1>Gym Membership API</h1>
               <p className="heroText">
                 Firebase login, admin authorization, member creation, editing,
-                and deletion in one clean interface.
+                deletion, and inactive-member reminders in one clean interface.
               </p>
             </div>
 
@@ -663,14 +724,22 @@ function App() {
             </section>
 
             <section className="panel">
-              <h2>Admin Dashboard</h2>
-              <p className="mutedText">Test admin-only access after login.</p>
-              <button
-                onClick={handleAdminDashboardRequest}
-                disabled={isLoading || !idToken}
-              >
-                Call Admin Dashboard
-              </button>
+              <h2>Admin Actions</h2>
+              <div className="actionGroup">
+                <button
+                  onClick={handleAdminDashboardRequest}
+                  disabled={isLoading || !idToken}
+                >
+                  Load Dashboard
+                </button>
+                <button
+                  className="secondary"
+                  onClick={handleLoadInactiveMembers}
+                  disabled={isLoading || !idToken}
+                >
+                  Load Inactive Members
+                </button>
+              </div>
             </section>
 
             <section className="panel">
@@ -756,7 +825,93 @@ function App() {
                     <strong>Dashboard not loaded yet.</strong>
                   </p>
                   <p className="mutedText">
-                    Sign in as admin and click <code>Call Admin Dashboard</code>.
+                    Sign in as admin and click <code>Load Dashboard</code>.
+                  </p>
+                </div>
+              )}
+            </section>
+
+            <section className="panel">
+              <div className="sectionHeader">
+                <div>
+                  <h2>
+                    Inactive Members{" "}
+                    <span className="countBadge">
+                      {inactiveMembersData?.totalInactiveMembers ?? 0}
+                    </span>
+                  </h2>
+                  <p className="mutedText">
+                    Members with no visits in the last{" "}
+                    <code>{inactiveMembersData?.thresholdDays ?? 14}</code> days.
+                  </p>
+                </div>
+              </div>
+
+              {inactiveMembersData ? (
+                inactiveMembersData.members.length > 0 ? (
+                  <div className="memberList">
+                    {inactiveMembersData.members.map((member) => (
+                      <div key={member.memberId} className="memberCard">
+                        <div
+                          className="memberAvatar"
+                          style={{
+                            backgroundColor: getAvatarColor(
+                              `${member.firstName}${member.lastName}${member.memberId}`,
+                            ),
+                          }}
+                        >
+                          {getInitials(member.firstName, member.lastName)}
+                        </div>
+
+                        <div className="memberInfo">
+                          <div className="memberCardTop">
+                            <strong>
+                              {member.firstName} {member.lastName}
+                            </strong>
+                            <span
+                              className={`memberBadge memberBadge-${member.membershipStatus}`}
+                            >
+                              {member.membershipStatus}
+                            </span>
+                          </div>
+
+                          <span className="memberEmail">{member.email}</span>
+
+                          <small className="memberId">
+                            {member.lastVisitDate
+                              ? `Last visit: ${toDateInputValue(member.lastVisitDate)} · ${member.daysSinceLastVisit} days ago`
+                              : "No visits recorded yet"}
+                          </small>
+
+                          <div className="actionGroup">
+                            <button
+                              className="secondary"
+                              onClick={() =>
+                                handleSendInactiveReminder(member.memberId)
+                              }
+                              disabled={isLoading || !idToken}
+                            >
+                              Send Reminder
+                            </button>
+                          </div>
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                ) : (
+                  <div className="emptyState">
+                    <p>
+                      <strong>No inactive members found.</strong>
+                    </p>
+                  </div>
+                )
+              ) : (
+                <div className="emptyState">
+                  <p>
+                    <strong>Inactive members not loaded yet.</strong>
+                  </p>
+                  <p className="mutedText">
+                    Click <code>Load Inactive Members</code>.
                   </p>
                 </div>
               )}

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -42,6 +42,11 @@ const parseJsonResponse = async (response: Response) => {
   }
 };
 
+const getAuthorizedHeaders = (idToken: string) => ({
+  "Content-Type": "application/json",
+  Authorization: `Bearer ${idToken}`,
+});
+
 export const loginWithFirebase = async ({
   email,
   password,
@@ -89,9 +94,12 @@ export const getAdminDashboard = async (idToken: string) => {
   return responseData;
 };
 
-export const getMembers = async (): Promise<Member[]> => {
+export const getMembers = async (idToken: string): Promise<Member[]> => {
   const response = await fetch(`${apiBaseUrl}/api/v1/members`, {
     method: "GET",
+    headers: {
+      Authorization: `Bearer ${idToken}`,
+    },
   });
 
   const responseData = await parseJsonResponse(response);
@@ -103,12 +111,13 @@ export const getMembers = async (): Promise<Member[]> => {
   return responseData as Member[];
 };
 
-export const createMember = async (memberInput: MemberInput) => {
+export const createMember = async (
+  idToken: string,
+  memberInput: MemberInput,
+) => {
   const response = await fetch(`${apiBaseUrl}/api/v1/members`, {
     method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-    },
+    headers: getAuthorizedHeaders(idToken),
     body: JSON.stringify(memberInput),
   });
 
@@ -122,14 +131,13 @@ export const createMember = async (memberInput: MemberInput) => {
 };
 
 export const updateMember = async (
+  idToken: string,
   memberId: string,
   memberInput: Partial<MemberInput>,
 ) => {
   const response = await fetch(`${apiBaseUrl}/api/v1/members/${memberId}`, {
     method: "PUT",
-    headers: {
-      "Content-Type": "application/json",
-    },
+    headers: getAuthorizedHeaders(idToken),
     body: JSON.stringify(memberInput),
   });
 
@@ -142,9 +150,12 @@ export const updateMember = async (
   return responseData;
 };
 
-export const deleteMember = async (memberId: string) => {
+export const deleteMember = async (idToken: string, memberId: string) => {
   const response = await fetch(`${apiBaseUrl}/api/v1/members/${memberId}`, {
     method: "DELETE",
+    headers: {
+      Authorization: `Bearer ${idToken}`,
+    },
   });
 
   const responseData = await parseJsonResponse(response);

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -32,6 +32,36 @@ export interface Member extends MemberInput {
   updatedAt: string;
 }
 
+export interface SubscriptionInput {
+  memberId: string;
+  planName: string;
+  startDate: string;
+  endDate: string;
+  price: number;
+  isActive: boolean;
+  paymentStatus: "paid" | "unpaid" | "overdue";
+}
+
+export interface Subscription extends SubscriptionInput {
+  id: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface VisitInput {
+  memberId: string;
+  visitDate: string;
+  checkInTime: string;
+  checkOutTime: string;
+  notes: string;
+}
+
+export interface Visit extends VisitInput {
+  id: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
 export interface AdminDashboardResponse {
   message: string;
   dashboard: {
@@ -303,4 +333,39 @@ export const deleteMember = async (idToken: string, memberId: string) => {
   }
 
   return responseData;
+};
+
+export const createSubscription = async (
+  idToken: string,
+  subscriptionInput: SubscriptionInput,
+) => {
+  const response = await fetch(`${apiBaseUrl}/api/v1/subscriptions`, {
+    method: "POST",
+    headers: getAuthorizedHeaders(idToken),
+    body: JSON.stringify(subscriptionInput),
+  });
+
+  const responseData = await parseJsonResponse(response);
+
+  if (!response.ok) {
+    throw new Error(responseData.message || "Failed to create subscription");
+  }
+
+  return responseData as Subscription;
+};
+
+export const createVisit = async (idToken: string, visitInput: VisitInput) => {
+  const response = await fetch(`${apiBaseUrl}/api/v1/visits`, {
+    method: "POST",
+    headers: getAuthorizedHeaders(idToken),
+    body: JSON.stringify(visitInput),
+  });
+
+  const responseData = await parseJsonResponse(response);
+
+  if (!response.ok) {
+    throw new Error(responseData.message || "Failed to create visit");
+  }
+
+  return responseData as Visit;
 };

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -32,6 +32,18 @@ export interface Member extends MemberInput {
   updatedAt: string;
 }
 
+export interface AdminDashboardResponse {
+  message: string;
+  dashboard: {
+    totalMembers: number;
+    totalSubscriptions: number;
+    totalVisits: number;
+    activeMembersCount: number;
+    inactiveMembersCount: number;
+    suspendedMembersCount: number;
+  };
+}
+
 const parseJsonResponse = async (response: Response) => {
   const responseText = await response.text();
 
@@ -77,7 +89,9 @@ export const loginWithFirebase = async ({
   return responseData as FirebaseLoginResponse;
 };
 
-export const getAdminDashboard = async (idToken: string) => {
+export const getAdminDashboard = async (
+  idToken: string,
+): Promise<AdminDashboardResponse> => {
   const response = await fetch(`${apiBaseUrl}/api/v1/admin/dashboard`, {
     method: "GET",
     headers: {
@@ -91,7 +105,7 @@ export const getAdminDashboard = async (idToken: string) => {
     throw new Error(responseData.message || "Failed to load admin dashboard");
   }
 
-  return responseData;
+  return responseData as AdminDashboardResponse;
 };
 
 export const getMembers = async (idToken: string): Promise<Member[]> => {

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -60,6 +60,25 @@ export interface InactiveMembersResponse {
   members: InactiveMemberSummary[];
 }
 
+export interface ExpiringSubscriptionSummary {
+  subscriptionId: string;
+  memberId: string;
+  firstName: string;
+  lastName: string;
+  email: string;
+  planName: string;
+  endDate: string;
+  daysUntilEnd: number;
+  paymentStatus: string;
+  isActive: boolean;
+}
+
+export interface ExpiringSubscriptionsResponse {
+  thresholdDays: number;
+  totalExpiringSubscriptions: number;
+  subscriptions: ExpiringSubscriptionSummary[];
+}
+
 const parseJsonResponse = async (response: Response) => {
   const responseText = await response.text();
 
@@ -160,6 +179,53 @@ export const sendInactiveMemberReminder = async (
   if (!response.ok) {
     throw new Error(
       responseData.message || "Failed to send inactive member reminder",
+    );
+  }
+
+  return responseData;
+};
+
+export const getExpiringSubscriptions = async (
+  idToken: string,
+): Promise<ExpiringSubscriptionsResponse> => {
+  const response = await fetch(
+    `${apiBaseUrl}/api/v1/admin/expiring-subscriptions`,
+    {
+      method: "GET",
+      headers: {
+        Authorization: `Bearer ${idToken}`,
+      },
+    },
+  );
+
+  const responseData = await parseJsonResponse(response);
+
+  if (!response.ok) {
+    throw new Error(
+      responseData.message || "Failed to load expiring subscriptions",
+    );
+  }
+
+  return responseData as ExpiringSubscriptionsResponse;
+};
+
+export const sendExpiringSubscriptionReminder = async (
+  idToken: string,
+  subscriptionId: string,
+) => {
+  const response = await fetch(
+    `${apiBaseUrl}/api/v1/admin/expiring-subscriptions/${subscriptionId}/reminder`,
+    {
+      method: "POST",
+      headers: getAuthorizedHeaders(idToken),
+    },
+  );
+
+  const responseData = await parseJsonResponse(response);
+
+  if (!response.ok) {
+    throw new Error(
+      responseData.message || "Failed to send subscription reminder",
     );
   }
 

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -44,6 +44,22 @@ export interface AdminDashboardResponse {
   };
 }
 
+export interface InactiveMemberSummary {
+  memberId: string;
+  firstName: string;
+  lastName: string;
+  email: string;
+  membershipStatus: "active" | "inactive" | "suspended";
+  lastVisitDate: string | null;
+  daysSinceLastVisit: number | null;
+}
+
+export interface InactiveMembersResponse {
+  thresholdDays: number;
+  totalInactiveMembers: number;
+  members: InactiveMemberSummary[];
+}
+
 const parseJsonResponse = async (response: Response) => {
   const responseText = await response.text();
 
@@ -106,6 +122,48 @@ export const getAdminDashboard = async (
   }
 
   return responseData as AdminDashboardResponse;
+};
+
+export const getInactiveMembers = async (
+  idToken: string,
+): Promise<InactiveMembersResponse> => {
+  const response = await fetch(`${apiBaseUrl}/api/v1/admin/inactive-members`, {
+    method: "GET",
+    headers: {
+      Authorization: `Bearer ${idToken}`,
+    },
+  });
+
+  const responseData = await parseJsonResponse(response);
+
+  if (!response.ok) {
+    throw new Error(responseData.message || "Failed to load inactive members");
+  }
+
+  return responseData as InactiveMembersResponse;
+};
+
+export const sendInactiveMemberReminder = async (
+  idToken: string,
+  memberId: string,
+) => {
+  const response = await fetch(
+    `${apiBaseUrl}/api/v1/admin/inactive-members/${memberId}/reminder`,
+    {
+      method: "POST",
+      headers: getAuthorizedHeaders(idToken),
+    },
+  );
+
+  const responseData = await parseJsonResponse(response);
+
+  if (!response.ok) {
+    throw new Error(
+      responseData.message || "Failed to send inactive member reminder",
+    );
+  }
+
+  return responseData;
 };
 
 export const getMembers = async (idToken: string): Promise<Member[]> => {

--- a/src/api/v1/controllers/admin.controller.ts
+++ b/src/api/v1/controllers/admin.controller.ts
@@ -19,6 +19,41 @@ const getAdminDashboard = async (
   }
 };
 
+const getInactiveMembers = async (
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): Promise<void> => {
+  try {
+    const inactiveMembersResponse = await adminService.getInactiveMembers();
+
+    res.status(HTTP_STATUS.OK).json(inactiveMembersResponse);
+  } catch (error) {
+    next(error);
+  }
+};
+
+const sendInactiveMemberReminder = async (
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): Promise<void> => {
+  try {
+    const inactiveMember = await adminService.sendInactiveMemberReminder(
+      req.params.memberId,
+    );
+
+    res.status(HTTP_STATUS.OK).json({
+      message: `Inactive reminder sent to ${inactiveMember.email}`,
+      member: inactiveMember,
+    });
+  } catch (error) {
+    next(error);
+  }
+};
+
 export const adminController = {
   getAdminDashboard,
+  getInactiveMembers,
+  sendInactiveMemberReminder,
 };

--- a/src/api/v1/controllers/admin.controller.ts
+++ b/src/api/v1/controllers/admin.controller.ts
@@ -1,6 +1,25 @@
 import { type NextFunction, type Request, type Response } from "express";
 import { HTTP_STATUS } from "../../../constants/httpStatus";
+import AppError from "../errors/AppError";
 import { adminService } from "../services/admin.service";
+
+const getSingleRouteParam = (
+  routeParam: string | string[] | undefined,
+  parameterName: string,
+): string => {
+  if (typeof routeParam === "string" && routeParam.trim()) {
+    return routeParam;
+  }
+
+  if (Array.isArray(routeParam) && routeParam.length > 0) {
+    return routeParam[0];
+  }
+
+  throw new AppError(
+    `Missing required route parameter: ${parameterName}`,
+    HTTP_STATUS.BAD_REQUEST,
+  );
+};
 
 const getAdminDashboard = async (
   req: Request,
@@ -39,8 +58,10 @@ const sendInactiveMemberReminder = async (
   next: NextFunction,
 ): Promise<void> => {
   try {
+    const memberId = getSingleRouteParam(req.params.memberId, "memberId");
+
     const inactiveMember = await adminService.sendInactiveMemberReminder(
-      req.params.memberId,
+      memberId,
     );
 
     res.status(HTTP_STATUS.OK).json({
@@ -52,8 +73,48 @@ const sendInactiveMemberReminder = async (
   }
 };
 
+const getExpiringSubscriptions = async (
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): Promise<void> => {
+  try {
+    const expiringSubscriptionsResponse =
+      await adminService.getExpiringSubscriptions();
+
+    res.status(HTTP_STATUS.OK).json(expiringSubscriptionsResponse);
+  } catch (error) {
+    next(error);
+  }
+};
+
+const sendExpiringSubscriptionReminder = async (
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): Promise<void> => {
+  try {
+    const subscriptionId = getSingleRouteParam(
+      req.params.subscriptionId,
+      "subscriptionId",
+    );
+
+    const expiringSubscription =
+      await adminService.sendExpiringSubscriptionReminder(subscriptionId);
+
+    res.status(HTTP_STATUS.OK).json({
+      message: `Subscription reminder sent to ${expiringSubscription.email}`,
+      subscription: expiringSubscription,
+    });
+  } catch (error) {
+    next(error);
+  }
+};
+
 export const adminController = {
   getAdminDashboard,
   getInactiveMembers,
   sendInactiveMemberReminder,
+  getExpiringSubscriptions,
+  sendExpiringSubscriptionReminder,
 };

--- a/src/api/v1/repositories/admin.repository.ts
+++ b/src/api/v1/repositories/admin.repository.ts
@@ -1,5 +1,6 @@
 import { getFirestoreDatabase } from "../../../config/firebase";
 import { type AdminDashboardStats } from "../types/admin.types";
+import { type Member } from "../types/member.types";
 
 const getAdminDashboardStats = async (): Promise<AdminDashboardStats> => {
   const firestoreDatabase = getFirestoreDatabase();
@@ -10,10 +11,29 @@ const getAdminDashboardStats = async (): Promise<AdminDashboardStats> => {
     .get();
   const visitsSnapshot = await firestoreDatabase.collection("visits").get();
 
+  const members = membersSnapshot.docs.map(
+    (memberDocument) => memberDocument.data() as Member,
+  );
+
+  const activeMembersCount = members.filter(
+    (member) => member.membershipStatus === "active",
+  ).length;
+
+  const inactiveMembersCount = members.filter(
+    (member) => member.membershipStatus === "inactive",
+  ).length;
+
+  const suspendedMembersCount = members.filter(
+    (member) => member.membershipStatus === "suspended",
+  ).length;
+
   return {
     totalMembers: membersSnapshot.size,
     totalSubscriptions: subscriptionsSnapshot.size,
     totalVisits: visitsSnapshot.size,
+    activeMembersCount,
+    inactiveMembersCount,
+    suspendedMembersCount,
   };
 };
 

--- a/src/api/v1/repositories/admin.repository.ts
+++ b/src/api/v1/repositories/admin.repository.ts
@@ -1,13 +1,17 @@
 import { getFirestoreDatabase } from "../../../config/firebase";
 import {
   type AdminDashboardStats,
+  type ExpiringSubscriptionSummary,
+  type ExpiringSubscriptionsResponse,
   type InactiveMemberSummary,
   type InactiveMembersResponse,
 } from "../types/admin.types";
 import { type Member } from "../types/member.types";
+import { type Subscription } from "../types/subscription.types";
 import { type Visit } from "../types/visit.types";
 
 const inactiveMemberThresholdDays = 14;
+const expiringSubscriptionThresholdDays = 7;
 
 const getDaysSinceDate = (dateString: string): number | null => {
   const date = new Date(dateString);
@@ -20,6 +24,19 @@ const getDaysSinceDate = (dateString: string): number | null => {
   const differenceInMilliseconds = Date.now() - date.getTime();
 
   return Math.max(0, Math.floor(differenceInMilliseconds / millisecondsPerDay));
+};
+
+const getDaysUntilDate = (dateString: string): number | null => {
+  const date = new Date(dateString);
+
+  if (Number.isNaN(date.getTime())) {
+    return null;
+  }
+
+  const millisecondsPerDay = 1000 * 60 * 60 * 24;
+  const differenceInMilliseconds = date.getTime() - Date.now();
+
+  return Math.max(0, Math.ceil(differenceInMilliseconds / millisecondsPerDay));
 };
 
 const buildLatestVisitByMemberIdMap = (visits: Visit[]): Map<string, string> => {
@@ -138,7 +155,81 @@ const getInactiveMembers = async (): Promise<InactiveMembersResponse> => {
   };
 };
 
+const getExpiringSubscriptions =
+  async (): Promise<ExpiringSubscriptionsResponse> => {
+    const firestoreDatabase = getFirestoreDatabase();
+
+    const membersSnapshot = await firestoreDatabase.collection("members").get();
+    const subscriptionsSnapshot = await firestoreDatabase
+      .collection("subscriptions")
+      .get();
+
+    const members = membersSnapshot.docs.map(
+      (memberDocument) => memberDocument.data() as Member,
+    );
+    const subscriptions = subscriptionsSnapshot.docs.map(
+      (subscriptionDocument) => subscriptionDocument.data() as Subscription,
+    );
+
+    const memberById = new Map<string, Member>();
+
+    for (const member of members) {
+      memberById.set(member.id, member);
+    }
+
+    const expiringSubscriptions: ExpiringSubscriptionSummary[] = [];
+
+    for (const subscription of subscriptions) {
+      const member = memberById.get(subscription.memberId);
+
+      if (!member) {
+        continue;
+      }
+
+      const daysUntilEnd = getDaysUntilDate(subscription.endDate);
+
+      if (daysUntilEnd === null) {
+        continue;
+      }
+
+      if (!subscription.isActive) {
+        continue;
+      }
+
+      if (daysUntilEnd > expiringSubscriptionThresholdDays) {
+        continue;
+      }
+
+      const expiringSubscription: ExpiringSubscriptionSummary = {
+        subscriptionId: subscription.id,
+        memberId: member.id,
+        firstName: member.firstName,
+        lastName: member.lastName,
+        email: member.email,
+        planName: subscription.planName,
+        endDate: subscription.endDate,
+        daysUntilEnd,
+        paymentStatus: subscription.paymentStatus,
+        isActive: subscription.isActive,
+      };
+
+      expiringSubscriptions.push(expiringSubscription);
+    }
+
+    expiringSubscriptions.sort(
+      (firstSubscription, secondSubscription) =>
+        firstSubscription.daysUntilEnd - secondSubscription.daysUntilEnd,
+    );
+
+    return {
+      thresholdDays: expiringSubscriptionThresholdDays,
+      totalExpiringSubscriptions: expiringSubscriptions.length,
+      subscriptions: expiringSubscriptions,
+    };
+  };
+
 export const adminRepository = {
   getAdminDashboardStats,
   getInactiveMembers,
+  getExpiringSubscriptions,
 };

--- a/src/api/v1/repositories/admin.repository.ts
+++ b/src/api/v1/repositories/admin.repository.ts
@@ -1,6 +1,43 @@
 import { getFirestoreDatabase } from "../../../config/firebase";
-import { type AdminDashboardStats } from "../types/admin.types";
+import {
+  type AdminDashboardStats,
+  type InactiveMemberSummary,
+  type InactiveMembersResponse,
+} from "../types/admin.types";
 import { type Member } from "../types/member.types";
+import { type Visit } from "../types/visit.types";
+
+const inactiveMemberThresholdDays = 14;
+
+const getDaysSinceDate = (dateString: string): number | null => {
+  const date = new Date(dateString);
+
+  if (Number.isNaN(date.getTime())) {
+    return null;
+  }
+
+  const millisecondsPerDay = 1000 * 60 * 60 * 24;
+  const differenceInMilliseconds = Date.now() - date.getTime();
+
+  return Math.max(0, Math.floor(differenceInMilliseconds / millisecondsPerDay));
+};
+
+const buildLatestVisitByMemberIdMap = (visits: Visit[]): Map<string, string> => {
+  const latestVisitByMemberId = new Map<string, string>();
+
+  for (const visit of visits) {
+    const currentLatestVisitDate = latestVisitByMemberId.get(visit.memberId);
+
+    if (
+      !currentLatestVisitDate ||
+      new Date(visit.visitDate).getTime() > new Date(currentLatestVisitDate).getTime()
+    ) {
+      latestVisitByMemberId.set(visit.memberId, visit.visitDate);
+    }
+  }
+
+  return latestVisitByMemberId;
+};
 
 const getAdminDashboardStats = async (): Promise<AdminDashboardStats> => {
   const firestoreDatabase = getFirestoreDatabase();
@@ -37,6 +74,71 @@ const getAdminDashboardStats = async (): Promise<AdminDashboardStats> => {
   };
 };
 
+const getInactiveMembers = async (): Promise<InactiveMembersResponse> => {
+  const firestoreDatabase = getFirestoreDatabase();
+
+  const membersSnapshot = await firestoreDatabase.collection("members").get();
+  const visitsSnapshot = await firestoreDatabase.collection("visits").get();
+
+  const members = membersSnapshot.docs.map(
+    (memberDocument) => memberDocument.data() as Member,
+  );
+  const visits = visitsSnapshot.docs.map(
+    (visitDocument) => visitDocument.data() as Visit,
+  );
+
+  const latestVisitByMemberId = buildLatestVisitByMemberIdMap(visits);
+
+  const inactiveMembers: InactiveMemberSummary[] = members
+    .map((member) => {
+      const lastVisitDate = latestVisitByMemberId.get(member.id) ?? null;
+      const daysSinceLastVisit = lastVisitDate
+        ? getDaysSinceDate(lastVisitDate)
+        : null;
+
+      return {
+        memberId: member.id,
+        firstName: member.firstName,
+        lastName: member.lastName,
+        email: member.email,
+        membershipStatus: member.membershipStatus,
+        lastVisitDate,
+        daysSinceLastVisit,
+      };
+    })
+    .filter((member) => {
+      if (member.lastVisitDate === null) {
+        return true;
+      }
+
+      if (member.daysSinceLastVisit === null) {
+        return false;
+      }
+
+      return member.daysSinceLastVisit >= inactiveMemberThresholdDays;
+    })
+    .sort((firstMember, secondMember) => {
+      const firstValue =
+        firstMember.daysSinceLastVisit === null
+          ? Number.MAX_SAFE_INTEGER
+          : firstMember.daysSinceLastVisit;
+
+      const secondValue =
+        secondMember.daysSinceLastVisit === null
+          ? Number.MAX_SAFE_INTEGER
+          : secondMember.daysSinceLastVisit;
+
+      return secondValue - firstValue;
+    });
+
+  return {
+    thresholdDays: inactiveMemberThresholdDays,
+    totalInactiveMembers: inactiveMembers.length,
+    members: inactiveMembers,
+  };
+};
+
 export const adminRepository = {
   getAdminDashboardStats,
+  getInactiveMembers,
 };

--- a/src/api/v1/routes/admin.routes.ts
+++ b/src/api/v1/routes/admin.routes.ts
@@ -26,4 +26,18 @@ adminRoutes.post(
   adminController.sendInactiveMemberReminder,
 );
 
+adminRoutes.get(
+  "/expiring-subscriptions",
+  authenticate,
+  authorize("admin"),
+  adminController.getExpiringSubscriptions,
+);
+
+adminRoutes.post(
+  "/expiring-subscriptions/:subscriptionId/reminder",
+  authenticate,
+  authorize("admin"),
+  adminController.sendExpiringSubscriptionReminder,
+);
+
 export default adminRoutes;

--- a/src/api/v1/routes/admin.routes.ts
+++ b/src/api/v1/routes/admin.routes.ts
@@ -1,7 +1,7 @@
 import { Router } from "express";
+import { adminController } from "../controllers/admin.controller";
 import authenticate from "../middleware/authenticate";
 import authorize from "../middleware/authorize";
-import { adminController } from "../controllers/admin.controller";
 
 const adminRoutes = Router();
 
@@ -10,6 +10,20 @@ adminRoutes.get(
   authenticate,
   authorize("admin"),
   adminController.getAdminDashboard,
+);
+
+adminRoutes.get(
+  "/inactive-members",
+  authenticate,
+  authorize("admin"),
+  adminController.getInactiveMembers,
+);
+
+adminRoutes.post(
+  "/inactive-members/:memberId/reminder",
+  authenticate,
+  authorize("admin"),
+  adminController.sendInactiveMemberReminder,
 );
 
 export default adminRoutes;

--- a/src/api/v1/routes/admin.routes.ts
+++ b/src/api/v1/routes/admin.routes.ts
@@ -5,6 +5,58 @@ import authorize from "../middleware/authorize";
 
 const adminRoutes = Router();
 
+/**
+ * @swagger
+ * tags:
+ *   name: Admin
+ *   description: Admin-only dashboard and reminder endpoints
+ */
+
+/**
+ * @swagger
+ * /api/v1/admin/dashboard:
+ *   get:
+ *     summary: Get admin dashboard statistics
+ *     tags: [Admin]
+ *     security:
+ *       - bearerAuth: []
+ *     responses:
+ *       200:
+ *         description: Admin dashboard loaded successfully
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 message:
+ *                   type: string
+ *                   example: Admin access granted
+ *                 dashboard:
+ *                   type: object
+ *                   properties:
+ *                     totalMembers:
+ *                       type: number
+ *                       example: 12
+ *                     totalSubscriptions:
+ *                       type: number
+ *                       example: 8
+ *                     totalVisits:
+ *                       type: number
+ *                       example: 37
+ *                     activeMembersCount:
+ *                       type: number
+ *                       example: 9
+ *                     inactiveMembersCount:
+ *                       type: number
+ *                       example: 2
+ *                     suspendedMembersCount:
+ *                       type: number
+ *                       example: 1
+ *       401:
+ *         description: Authorization token is missing or invalid
+ *       403:
+ *         description: Forbidden
+ */
 adminRoutes.get(
   "/dashboard",
   authenticate,
@@ -12,6 +64,61 @@ adminRoutes.get(
   adminController.getAdminDashboard,
 );
 
+/**
+ * @swagger
+ * /api/v1/admin/inactive-members:
+ *   get:
+ *     summary: Get inactive members based on recent visit activity
+ *     tags: [Admin]
+ *     security:
+ *       - bearerAuth: []
+ *     responses:
+ *       200:
+ *         description: Inactive members loaded successfully
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 thresholdDays:
+ *                   type: number
+ *                   example: 14
+ *                 totalInactiveMembers:
+ *                   type: number
+ *                   example: 3
+ *                 members:
+ *                   type: array
+ *                   items:
+ *                     type: object
+ *                     properties:
+ *                       memberId:
+ *                         type: string
+ *                         example: member_123
+ *                       firstName:
+ *                         type: string
+ *                         example: Timur
+ *                       lastName:
+ *                         type: string
+ *                         example: Karimov
+ *                       email:
+ *                         type: string
+ *                         example: tkarimov@academic.rrc.ca
+ *                       membershipStatus:
+ *                         type: string
+ *                         example: active
+ *                       lastVisitDate:
+ *                         type: string
+ *                         nullable: true
+ *                         example: 2026-04-01T00:00:00.000Z
+ *                       daysSinceLastVisit:
+ *                         type: number
+ *                         nullable: true
+ *                         example: 19
+ *       401:
+ *         description: Authorization token is missing or invalid
+ *       403:
+ *         description: Forbidden
+ */
 adminRoutes.get(
   "/inactive-members",
   authenticate,
@@ -19,6 +126,67 @@ adminRoutes.get(
   adminController.getInactiveMembers,
 );
 
+/**
+ * @swagger
+ * /api/v1/admin/inactive-members/{memberId}/reminder:
+ *   post:
+ *     summary: Send reminder email to an inactive member
+ *     tags: [Admin]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: memberId
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: Member ID
+ *     responses:
+ *       200:
+ *         description: Inactive reminder sent successfully
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 message:
+ *                   type: string
+ *                   example: Inactive reminder sent to tkarimov@academic.rrc.ca
+ *                 member:
+ *                   type: object
+ *                   properties:
+ *                     memberId:
+ *                       type: string
+ *                       example: member_123
+ *                     firstName:
+ *                       type: string
+ *                       example: Timur
+ *                     lastName:
+ *                       type: string
+ *                       example: Karimov
+ *                     email:
+ *                       type: string
+ *                       example: tkarimov@academic.rrc.ca
+ *                     membershipStatus:
+ *                       type: string
+ *                       example: active
+ *                     lastVisitDate:
+ *                       type: string
+ *                       nullable: true
+ *                       example: 2026-04-01T00:00:00.000Z
+ *                     daysSinceLastVisit:
+ *                       type: number
+ *                       nullable: true
+ *                       example: 19
+ *       400:
+ *         description: Email configuration is not available
+ *       401:
+ *         description: Authorization token is missing or invalid
+ *       403:
+ *         description: Forbidden
+ *       404:
+ *         description: Inactive member not found
+ */
 adminRoutes.post(
   "/inactive-members/:memberId/reminder",
   authenticate,
@@ -26,6 +194,68 @@ adminRoutes.post(
   adminController.sendInactiveMemberReminder,
 );
 
+/**
+ * @swagger
+ * /api/v1/admin/expiring-subscriptions:
+ *   get:
+ *     summary: Get subscriptions that are expiring soon
+ *     tags: [Admin]
+ *     security:
+ *       - bearerAuth: []
+ *     responses:
+ *       200:
+ *         description: Expiring subscriptions loaded successfully
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 thresholdDays:
+ *                   type: number
+ *                   example: 7
+ *                 totalExpiringSubscriptions:
+ *                   type: number
+ *                   example: 2
+ *                 subscriptions:
+ *                   type: array
+ *                   items:
+ *                     type: object
+ *                     properties:
+ *                       subscriptionId:
+ *                         type: string
+ *                         example: sub_123
+ *                       memberId:
+ *                         type: string
+ *                         example: member_123
+ *                       firstName:
+ *                         type: string
+ *                         example: Timur
+ *                       lastName:
+ *                         type: string
+ *                         example: Karimov
+ *                       email:
+ *                         type: string
+ *                         example: tkarimov@academic.rrc.ca
+ *                       planName:
+ *                         type: string
+ *                         example: Monthly Premium
+ *                       endDate:
+ *                         type: string
+ *                         example: 2026-04-21T00:00:00.000Z
+ *                       daysUntilEnd:
+ *                         type: number
+ *                         example: 1
+ *                       paymentStatus:
+ *                         type: string
+ *                         example: paid
+ *                       isActive:
+ *                         type: boolean
+ *                         example: true
+ *       401:
+ *         description: Authorization token is missing or invalid
+ *       403:
+ *         description: Forbidden
+ */
 adminRoutes.get(
   "/expiring-subscriptions",
   authenticate,
@@ -33,6 +263,74 @@ adminRoutes.get(
   adminController.getExpiringSubscriptions,
 );
 
+/**
+ * @swagger
+ * /api/v1/admin/expiring-subscriptions/{subscriptionId}/reminder:
+ *   post:
+ *     summary: Send reminder email for an expiring subscription
+ *     tags: [Admin]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: subscriptionId
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: Subscription ID
+ *     responses:
+ *       200:
+ *         description: Subscription reminder sent successfully
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 message:
+ *                   type: string
+ *                   example: Subscription reminder sent to tkarimov@academic.rrc.ca
+ *                 subscription:
+ *                   type: object
+ *                   properties:
+ *                     subscriptionId:
+ *                       type: string
+ *                       example: sub_123
+ *                     memberId:
+ *                       type: string
+ *                       example: member_123
+ *                     firstName:
+ *                       type: string
+ *                       example: Timur
+ *                     lastName:
+ *                       type: string
+ *                       example: Karimov
+ *                     email:
+ *                       type: string
+ *                       example: tkarimov@academic.rrc.ca
+ *                     planName:
+ *                       type: string
+ *                       example: Monthly Premium
+ *                     endDate:
+ *                       type: string
+ *                       example: 2026-04-21T00:00:00.000Z
+ *                     daysUntilEnd:
+ *                       type: number
+ *                       example: 1
+ *                     paymentStatus:
+ *                       type: string
+ *                       example: paid
+ *                     isActive:
+ *                       type: boolean
+ *                       example: true
+ *       400:
+ *         description: Email configuration is not available
+ *       401:
+ *         description: Authorization token is missing or invalid
+ *       403:
+ *         description: Forbidden
+ *       404:
+ *         description: Expiring subscription not found
+ */
 adminRoutes.post(
   "/expiring-subscriptions/:subscriptionId/reminder",
   authenticate,

--- a/src/api/v1/routes/member.routes.ts
+++ b/src/api/v1/routes/member.routes.ts
@@ -1,112 +1,43 @@
 import { Router } from "express";
 import { memberController } from "../controllers/member.controller";
+import authenticate from "../middleware/authenticate";
+import authorize from "../middleware/authorize";
 
 const memberRoutes = Router();
 
-/**
- * @swagger
- * /api/v1/members:
- *   post:
- *     summary: Create a new member
- *     tags:
- *       - Members
- *     requestBody:
- *       required: true
- *       content:
- *         application/json:
- *           schema:
- *             $ref: '#/components/schemas/CreateMemberInput'
- *     responses:
- *       201:
- *         description: Member created successfully
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/Member'
- *       400:
- *         description: Validation failed
- *   get:
- *     summary: Get all members
- *     tags:
- *       - Members
- *     responses:
- *       200:
- *         description: A list of members
- *         content:
- *           application/json:
- *             schema:
- *               type: array
- *               items:
- *                 $ref: '#/components/schemas/Member'
- */
-memberRoutes.post("/", memberController.createMember);
-memberRoutes.get("/", memberController.getAllMembers);
+memberRoutes.get(
+  "/",
+  authenticate,
+  authorize("admin"),
+  memberController.getAllMembers,
+);
 
-/**
- * @swagger
- * /api/v1/members/{memberId}:
- *   get:
- *     summary: Get a member by id
- *     tags:
- *       - Members
- *     parameters:
- *       - in: path
- *         name: memberId
- *         required: true
- *         schema:
- *           type: string
- *     responses:
- *       200:
- *         description: Member found
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/Member'
- *       404:
- *         description: Member not found
- *   put:
- *     summary: Update a member by id
- *     tags:
- *       - Members
- *     parameters:
- *       - in: path
- *         name: memberId
- *         required: true
- *         schema:
- *           type: string
- *     requestBody:
- *       required: true
- *       content:
- *         application/json:
- *           schema:
- *             $ref: '#/components/schemas/UpdateMemberInput'
- *     responses:
- *       200:
- *         description: Member updated successfully
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/Member'
- *       404:
- *         description: Member not found
- *   delete:
- *     summary: Delete a member by id
- *     tags:
- *       - Members
- *     parameters:
- *       - in: path
- *         name: memberId
- *         required: true
- *         schema:
- *           type: string
- *     responses:
- *       200:
- *         description: Member deleted successfully
- *       404:
- *         description: Member not found
- */
-memberRoutes.get("/:memberId", memberController.getMemberById);
-memberRoutes.put("/:memberId", memberController.updateMember);
-memberRoutes.delete("/:memberId", memberController.deleteMember);
+memberRoutes.post(
+  "/",
+  authenticate,
+  authorize("admin"),
+  memberController.createMember,
+);
+
+memberRoutes.get(
+  "/:memberId",
+  authenticate,
+  authorize("admin"),
+  memberController.getMemberById,
+);
+
+memberRoutes.put(
+  "/:memberId",
+  authenticate,
+  authorize("admin"),
+  memberController.updateMember,
+);
+
+memberRoutes.delete(
+  "/:memberId",
+  authenticate,
+  authorize("admin"),
+  memberController.deleteMember,
+);
 
 export default memberRoutes;

--- a/src/api/v1/routes/member.routes.ts
+++ b/src/api/v1/routes/member.routes.ts
@@ -5,6 +5,72 @@ import authorize from "../middleware/authorize";
 
 const memberRoutes = Router();
 
+/**
+ * @swagger
+ * tags:
+ *   name: Members
+ *   description: Member management endpoints
+ */
+
+/**
+ * @swagger
+ * /api/v1/members:
+ *   get:
+ *     summary: Get all members
+ *     tags: [Members]
+ *     security:
+ *       - bearerAuth: []
+ *     responses:
+ *       200:
+ *         description: Members loaded successfully
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: array
+ *               items:
+ *                 type: object
+ *                 properties:
+ *                   id:
+ *                     type: string
+ *                     example: member_123
+ *                   firstName:
+ *                     type: string
+ *                     example: Timur
+ *                   lastName:
+ *                     type: string
+ *                     example: Karimov
+ *                   email:
+ *                     type: string
+ *                     example: tkarimov@academic.rrc.ca
+ *                   phoneNumber:
+ *                     type: string
+ *                     example: "2045551234"
+ *                   dateOfBirth:
+ *                     type: string
+ *                     example: 1999-04-16T00:00:00.000Z
+ *                   emergencyContactName:
+ *                     type: string
+ *                     example: John Karimov
+ *                   emergencyContactPhoneNumber:
+ *                     type: string
+ *                     example: "2045559999"
+ *                   membershipStatus:
+ *                     type: string
+ *                     example: active
+ *                   joinDate:
+ *                     type: string
+ *                     example: 2026-04-20T00:00:00.000Z
+ *                   createdAt:
+ *                     type: string
+ *                     example: 2026-04-20T03:00:00.000Z
+ *                   updatedAt:
+ *                     type: string
+ *                     example: 2026-04-20T03:00:00.000Z
+ *       401:
+ *         description: Authorization token is missing or invalid
+ *       403:
+ *         description: Forbidden
+ */
 memberRoutes.get(
   "/",
   authenticate,
@@ -12,6 +78,110 @@ memberRoutes.get(
   memberController.getAllMembers,
 );
 
+/**
+ * @swagger
+ * /api/v1/members:
+ *   post:
+ *     summary: Create a new member
+ *     tags: [Members]
+ *     security:
+ *       - bearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required:
+ *               - firstName
+ *               - lastName
+ *               - email
+ *               - phoneNumber
+ *               - dateOfBirth
+ *               - emergencyContactName
+ *               - emergencyContactPhoneNumber
+ *               - membershipStatus
+ *               - joinDate
+ *             properties:
+ *               firstName:
+ *                 type: string
+ *                 example: Timur
+ *               lastName:
+ *                 type: string
+ *                 example: Karimov
+ *               email:
+ *                 type: string
+ *                 example: tkarimov@academic.rrc.ca
+ *               phoneNumber:
+ *                 type: string
+ *                 example: "2045551234"
+ *               dateOfBirth:
+ *                 type: string
+ *                 example: 1999-04-16T00:00:00.000Z
+ *               emergencyContactName:
+ *                 type: string
+ *                 example: John Karimov
+ *               emergencyContactPhoneNumber:
+ *                 type: string
+ *                 example: "2045559999"
+ *               membershipStatus:
+ *                 type: string
+ *                 enum: [active, inactive, suspended]
+ *                 example: active
+ *               joinDate:
+ *                 type: string
+ *                 example: 2026-04-20T00:00:00.000Z
+ *     responses:
+ *       201:
+ *         description: Member created successfully
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 id:
+ *                   type: string
+ *                   example: member_123
+ *                 firstName:
+ *                   type: string
+ *                   example: Timur
+ *                 lastName:
+ *                   type: string
+ *                   example: Karimov
+ *                 email:
+ *                   type: string
+ *                   example: tkarimov@academic.rrc.ca
+ *                 phoneNumber:
+ *                   type: string
+ *                   example: "2045551234"
+ *                 dateOfBirth:
+ *                   type: string
+ *                   example: 1999-04-16T00:00:00.000Z
+ *                 emergencyContactName:
+ *                   type: string
+ *                   example: John Karimov
+ *                 emergencyContactPhoneNumber:
+ *                   type: string
+ *                   example: "2045559999"
+ *                 membershipStatus:
+ *                   type: string
+ *                   example: active
+ *                 joinDate:
+ *                   type: string
+ *                   example: 2026-04-20T00:00:00.000Z
+ *                 createdAt:
+ *                   type: string
+ *                   example: 2026-04-20T03:00:00.000Z
+ *                 updatedAt:
+ *                   type: string
+ *                   example: 2026-04-20T03:00:00.000Z
+ *       400:
+ *         description: Validation failed
+ *       401:
+ *         description: Authorization token is missing or invalid
+ *       403:
+ *         description: Forbidden
+ */
 memberRoutes.post(
   "/",
   authenticate,
@@ -19,6 +189,72 @@ memberRoutes.post(
   memberController.createMember,
 );
 
+/**
+ * @swagger
+ * /api/v1/members/{memberId}:
+ *   get:
+ *     summary: Get member by ID
+ *     tags: [Members]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: memberId
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: Member ID
+ *     responses:
+ *       200:
+ *         description: Member loaded successfully
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 id:
+ *                   type: string
+ *                   example: member_123
+ *                 firstName:
+ *                   type: string
+ *                   example: Timur
+ *                 lastName:
+ *                   type: string
+ *                   example: Karimov
+ *                 email:
+ *                   type: string
+ *                   example: tkarimov@academic.rrc.ca
+ *                 phoneNumber:
+ *                   type: string
+ *                   example: "2045551234"
+ *                 dateOfBirth:
+ *                   type: string
+ *                   example: 1999-04-16T00:00:00.000Z
+ *                 emergencyContactName:
+ *                   type: string
+ *                   example: John Karimov
+ *                 emergencyContactPhoneNumber:
+ *                   type: string
+ *                   example: "2045559999"
+ *                 membershipStatus:
+ *                   type: string
+ *                   example: active
+ *                 joinDate:
+ *                   type: string
+ *                   example: 2026-04-20T00:00:00.000Z
+ *                 createdAt:
+ *                   type: string
+ *                   example: 2026-04-20T03:00:00.000Z
+ *                 updatedAt:
+ *                   type: string
+ *                   example: 2026-04-20T03:00:00.000Z
+ *       401:
+ *         description: Authorization token is missing or invalid
+ *       403:
+ *         description: Forbidden
+ *       404:
+ *         description: Member not found
+ */
 memberRoutes.get(
   "/:memberId",
   authenticate,
@@ -26,6 +262,68 @@ memberRoutes.get(
   memberController.getMemberById,
 );
 
+/**
+ * @swagger
+ * /api/v1/members/{memberId}:
+ *   put:
+ *     summary: Update member by ID
+ *     tags: [Members]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: memberId
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: Member ID
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               firstName:
+ *                 type: string
+ *                 example: Timur
+ *               lastName:
+ *                 type: string
+ *                 example: Karimov
+ *               email:
+ *                 type: string
+ *                 example: tkarimov@academic.rrc.ca
+ *               phoneNumber:
+ *                 type: string
+ *                 example: "2045551234"
+ *               dateOfBirth:
+ *                 type: string
+ *                 example: 1999-04-16T00:00:00.000Z
+ *               emergencyContactName:
+ *                 type: string
+ *                 example: John Karimov
+ *               emergencyContactPhoneNumber:
+ *                 type: string
+ *                 example: "2045559999"
+ *               membershipStatus:
+ *                 type: string
+ *                 enum: [active, inactive, suspended]
+ *                 example: inactive
+ *               joinDate:
+ *                 type: string
+ *                 example: 2026-04-20T00:00:00.000Z
+ *     responses:
+ *       200:
+ *         description: Member updated successfully
+ *       400:
+ *         description: Validation failed
+ *       401:
+ *         description: Authorization token is missing or invalid
+ *       403:
+ *         description: Forbidden
+ *       404:
+ *         description: Member not found
+ */
 memberRoutes.put(
   "/:memberId",
   authenticate,
@@ -33,6 +331,31 @@ memberRoutes.put(
   memberController.updateMember,
 );
 
+/**
+ * @swagger
+ * /api/v1/members/{memberId}:
+ *   delete:
+ *     summary: Delete member by ID
+ *     tags: [Members]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: memberId
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: Member ID
+ *     responses:
+ *       200:
+ *         description: Member deleted successfully
+ *       401:
+ *         description: Authorization token is missing or invalid
+ *       403:
+ *         description: Forbidden
+ *       404:
+ *         description: Member not found
+ */
 memberRoutes.delete(
   "/:memberId",
   authenticate,

--- a/src/api/v1/services/admin.service.ts
+++ b/src/api/v1/services/admin.service.ts
@@ -4,6 +4,8 @@ import { adminRepository } from "../repositories/admin.repository";
 import { emailService } from "./email.service";
 import {
   type AdminDashboardStats,
+  type ExpiringSubscriptionSummary,
+  type ExpiringSubscriptionsResponse,
   type InactiveMemberSummary,
   type InactiveMembersResponse,
 } from "../types/admin.types";
@@ -45,8 +47,48 @@ const sendInactiveMemberReminder = async (
   return inactiveMember;
 };
 
+const getExpiringSubscriptions =
+  async (): Promise<ExpiringSubscriptionsResponse> => {
+    return adminRepository.getExpiringSubscriptions();
+  };
+
+const sendExpiringSubscriptionReminder = async (
+  subscriptionId: string,
+): Promise<ExpiringSubscriptionSummary> => {
+  const expiringSubscriptionsResponse =
+    await adminRepository.getExpiringSubscriptions();
+
+  const expiringSubscription = expiringSubscriptionsResponse.subscriptions.find(
+    (subscription) => subscription.subscriptionId === subscriptionId,
+  );
+
+  if (!expiringSubscription) {
+    throw new AppError(
+      "Expiring subscription not found",
+      HTTP_STATUS.NOT_FOUND,
+    );
+  }
+
+  if (!emailService.isEmailConfigurationAvailable()) {
+    throw new AppError(
+      "Email configuration is not available",
+      HTTP_STATUS.BAD_REQUEST,
+    );
+  }
+
+  await emailService.sendSubscriptionReminderEmail(
+    expiringSubscription.email,
+    expiringSubscription.firstName,
+    expiringSubscription.endDate,
+  );
+
+  return expiringSubscription;
+};
+
 export const adminService = {
   getAdminDashboardStats,
   getInactiveMembers,
   sendInactiveMemberReminder,
+  getExpiringSubscriptions,
+  sendExpiringSubscriptionReminder,
 };

--- a/src/api/v1/services/admin.service.ts
+++ b/src/api/v1/services/admin.service.ts
@@ -1,10 +1,52 @@
+import { HTTP_STATUS } from "../../../constants/httpStatus";
+import AppError from "../errors/AppError";
 import { adminRepository } from "../repositories/admin.repository";
-import { type AdminDashboardStats } from "../types/admin.types";
+import { emailService } from "./email.service";
+import {
+  type AdminDashboardStats,
+  type InactiveMemberSummary,
+  type InactiveMembersResponse,
+} from "../types/admin.types";
 
 const getAdminDashboardStats = async (): Promise<AdminDashboardStats> => {
   return adminRepository.getAdminDashboardStats();
 };
 
+const getInactiveMembers = async (): Promise<InactiveMembersResponse> => {
+  return adminRepository.getInactiveMembers();
+};
+
+const sendInactiveMemberReminder = async (
+  memberId: string,
+): Promise<InactiveMemberSummary> => {
+  const inactiveMembersResponse = await adminRepository.getInactiveMembers();
+
+  const inactiveMember = inactiveMembersResponse.members.find(
+    (member) => member.memberId === memberId,
+  );
+
+  if (!inactiveMember) {
+    throw new AppError("Inactive member not found", HTTP_STATUS.NOT_FOUND);
+  }
+
+  if (!emailService.isEmailConfigurationAvailable()) {
+    throw new AppError(
+      "Email configuration is not available",
+      HTTP_STATUS.BAD_REQUEST,
+    );
+  }
+
+  await emailService.sendInactiveMemberReminderEmail(
+    inactiveMember.email,
+    inactiveMember.firstName,
+    inactiveMember.daysSinceLastVisit,
+  );
+
+  return inactiveMember;
+};
+
 export const adminService = {
   getAdminDashboardStats,
+  getInactiveMembers,
+  sendInactiveMemberReminder,
 };

--- a/src/api/v1/services/email.service.ts
+++ b/src/api/v1/services/email.service.ts
@@ -60,9 +60,28 @@ const sendSubscriptionReminderEmail = async (
   });
 };
 
+const sendInactiveMemberReminderEmail = async (
+  recipientEmailAddress: string,
+  memberFirstName: string,
+  daysSinceLastVisit: number | null,
+): Promise<void> => {
+  const inactivityLine =
+    daysSinceLastVisit === null
+      ? "We still have not recorded a gym visit for your account."
+      : `We have not seen you at the gym in ${daysSinceLastVisit} days.`;
+
+  await sendEmail({
+    to: recipientEmailAddress,
+    subject: "We miss you at the gym",
+    text: `Hello ${memberFirstName}, ${inactivityLine} We would love to see you back soon.`,
+    html: `<p>Hello ${memberFirstName},</p><p>${inactivityLine}</p><p>We would love to see you back soon.</p>`,
+  });
+};
+
 export const emailService = {
   isEmailConfigurationAvailable,
   sendEmail,
   sendWelcomeEmail,
   sendSubscriptionReminderEmail,
+  sendInactiveMemberReminderEmail,
 };

--- a/src/api/v1/types/admin.types.ts
+++ b/src/api/v1/types/admin.types.ts
@@ -6,3 +6,19 @@ export interface AdminDashboardStats {
   inactiveMembersCount: number;
   suspendedMembersCount: number;
 }
+
+export interface InactiveMemberSummary {
+  memberId: string;
+  firstName: string;
+  lastName: string;
+  email: string;
+  membershipStatus: "active" | "inactive" | "suspended";
+  lastVisitDate: string | null;
+  daysSinceLastVisit: number | null;
+}
+
+export interface InactiveMembersResponse {
+  thresholdDays: number;
+  totalInactiveMembers: number;
+  members: InactiveMemberSummary[];
+}

--- a/src/api/v1/types/admin.types.ts
+++ b/src/api/v1/types/admin.types.ts
@@ -22,3 +22,22 @@ export interface InactiveMembersResponse {
   totalInactiveMembers: number;
   members: InactiveMemberSummary[];
 }
+
+export interface ExpiringSubscriptionSummary {
+  subscriptionId: string;
+  memberId: string;
+  firstName: string;
+  lastName: string;
+  email: string;
+  planName: string;
+  endDate: string;
+  daysUntilEnd: number;
+  paymentStatus: string;
+  isActive: boolean;
+}
+
+export interface ExpiringSubscriptionsResponse {
+  thresholdDays: number;
+  totalExpiringSubscriptions: number;
+  subscriptions: ExpiringSubscriptionSummary[];
+}

--- a/src/api/v1/types/admin.types.ts
+++ b/src/api/v1/types/admin.types.ts
@@ -2,4 +2,7 @@ export interface AdminDashboardStats {
   totalMembers: number;
   totalSubscriptions: number;
   totalVisits: number;
+  activeMembersCount: number;
+  inactiveMembersCount: number;
+  suspendedMembersCount: number;
 }


### PR DESCRIPTION
Completed work:
- added new admin response types for reminder-related data
- added repository logic to detect inactive members based on visit history
- added repository logic to detect subscriptions that are expiring soon
- added service-layer support for reminder workflows
- added controller methods for loading reminder data and sending reminder emails
- added protected admin routes for:
  - loading inactive members
  - sending inactive member reminders
  - loading expiring subscriptions
  - sending expiring subscription reminders
- updated the frontend API layer to support the new admin reminder endpoints
- updated the frontend UI to display:
  - inactive members
  - expiring subscriptions
  - reminder actions for both
- connected reminder actions to the existing email service
- verified the new functionality through the fronten